### PR TITLE
[SWE-230] Use new "Uploaded" annotation querying contract in FEA

### DIFF
--- a/packages/core/components/FileMetadataSearchBar/index.tsx
+++ b/packages/core/components/FileMetadataSearchBar/index.tsx
@@ -45,7 +45,7 @@ export function extractDateFromDateString(dateString?: string): Date | undefined
 function extractDatesFromRangeOperatorFilterString(
     filterString: string
 ): { startDate: Date; endDate: Date } | null {
-    // Regex with capture groups for identifying strings using the RANGE() operator with full ISO strings
+    // Regex with capture groups for identifying ISO datestrings in the RANGE() filter operator
     // e.g. RANGE(2022-01-01T00:00:00.000Z,2022-01-31T00:00:00.000Z)
     // Captures "2022-01-01T00:00:00.000Z" and "2022-01-31T00:00:00.000Z"
     const RANGE_OPERATOR_REGEX = /RANGE\(([\d\-:TZ.]+),([\d\-:TZ.]+)\)/g;

--- a/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
+++ b/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
@@ -92,7 +92,7 @@ describe("<FileMetadataSearchBar />", () => {
             TOP_LEVEL_FILE_ANNOTATIONS.find((a) => a.name === AnnotationName.UPLOADED)
                 ?.displayName || "";
         const date1 = "2021-03-04T00:00:00.000Z";
-        const date2 = "2020-08-30T00:00:00.000Z";
+        const date2 = "2020-08-31T00:00:00.000Z";
         const filter = new FileFilter(AnnotationName.UPLOADED, `RANGE(${date1},${date2})`);
         const state = {
             ...initialState,
@@ -113,7 +113,7 @@ describe("<FileMetadataSearchBar />", () => {
         expect(getByText("Sun Aug 30 2020")).to.not.be.empty;
     });
 
-    it("defaults end date to start date when only start date is chosen", async () => {
+    it("creates RANGE() file filter of RANGE(day,day+1) when only start date is selected", async () => {
         // Arrange
         const { actions, logicMiddleware, store } = configureMockStore({ state: initialState });
         const { getByText } = render(
@@ -121,18 +121,21 @@ describe("<FileMetadataSearchBar />", () => {
                 <FileMetadataSearchBar />
             </Provider>
         );
-        const date = new Date();
-        date.setHours(0);
-        date.setMinutes(0);
-        date.setSeconds(0);
-        date.setMilliseconds(0);
-        const expectedRange = `RANGE(${date.toISOString()},${date.toISOString()})`;
+        const startDate = new Date();
+        startDate.setDate(15);
+        startDate.setHours(0);
+        startDate.setMinutes(0);
+        startDate.setSeconds(0);
+        startDate.setMilliseconds(0);
+        const endDate = new Date(startDate);
+        endDate.setDate(endDate.getDate() + 1);
+        const expectedRange = `RANGE(${startDate.toISOString()},${endDate.toISOString()})`;
 
         // Act
         fireEvent.click(getByText("File name"));
         fireEvent.click(getByText("Uploaded"));
         fireEvent.click(getByText("Start of date range"));
-        fireEvent.click(getByText(`${date.getDate()}`));
+        fireEvent.click(getByText(15));
         await logicMiddleware.whenComplete();
 
         // Assert

--- a/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
+++ b/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
@@ -122,7 +122,8 @@ describe("<FileMetadataSearchBar />", () => {
             </Provider>
         );
         const startDate = new Date();
-        startDate.setDate(15);
+        const day = 15; // Arbitrary day of the month that isn't likely to render twice
+        startDate.setDate(day);
         startDate.setHours(0);
         startDate.setMinutes(0);
         startDate.setSeconds(0);
@@ -135,7 +136,7 @@ describe("<FileMetadataSearchBar />", () => {
         fireEvent.click(getByText("File name"));
         fireEvent.click(getByText("Uploaded"));
         fireEvent.click(getByText("Start of date range"));
-        fireEvent.click(getByText(15));
+        fireEvent.click(getByText(day));
         await logicMiddleware.whenComplete();
 
         // Assert

--- a/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
+++ b/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
@@ -86,31 +86,45 @@ describe("<FileMetadataSearchBar />", () => {
         expect(getByDisplayValue(filter.value)).to.not.be.empty;
     });
 
-    it("loads date search bar with filter from URL", () => {
-        // Arrange
-        const uploadedDisplayName =
-            TOP_LEVEL_FILE_ANNOTATIONS.find((a) => a.name === AnnotationName.UPLOADED)
-                ?.displayName || "";
-        const date1 = "2021-03-04T00:00:00.000Z";
-        const date2 = "2020-08-31T00:00:00.000Z";
-        const filter = new FileFilter(AnnotationName.UPLOADED, `RANGE(${date1},${date2})`);
-        const state = {
-            ...initialState,
-            selection: {
-                filters: [filter],
-            },
-        };
-        const { store } = configureMockStore({ state });
-        const { getByText } = render(
-            <Provider store={store}>
-                <FileMetadataSearchBar />
-            </Provider>
-        );
+    describe("load date search bar with filter from URL", () => {
+        [
+            ["2022-01-01", "2022-02-01", "Sat Jan 01 2022", "Mon Jan 31 2022"],
+            ["2022-01-01", "2022-01-31", "Sat Jan 01 2022", "Sun Jan 30 2022"],
+            ["2022-01-01", "2022-02-02", "Sat Jan 01 2022", "Tue Feb 01 2022"],
+            ["2022-01-31", "2022-01-02", "Mon Jan 31 2022", "Sat Jan 01 2022"],
+        ].forEach(([dateLowerBound, dateUpperBound, expectedDate1, expectedDate2]) => {
+            it(`loads correct dates for filter "RANGE(${dateLowerBound},{${dateUpperBound})"`, () => {
+                // Arrange
+                const uploadedDisplayName =
+                    TOP_LEVEL_FILE_ANNOTATIONS.find((a) => a.name === AnnotationName.UPLOADED)
+                        ?.displayName || "";
+                const dateLowerAsDate = new Date(dateLowerBound);
+                const dateUpperAsDate = new Date(dateUpperBound);
+                const dateLowerISO = dateLowerAsDate.toISOString();
+                const dateUpperISO = dateUpperAsDate.toISOString();
+                const filter = new FileFilter(
+                    AnnotationName.UPLOADED,
+                    `RANGE(${dateLowerISO},${dateUpperISO})`
+                );
+                const state = {
+                    ...initialState,
+                    selection: {
+                        filters: [filter],
+                    },
+                };
+                const { store } = configureMockStore({ state });
+                const { getByText } = render(
+                    <Provider store={store}>
+                        <FileMetadataSearchBar />
+                    </Provider>
+                );
 
-        // Assert
-        expect(getByText(uploadedDisplayName)).to.not.be.empty;
-        expect(getByText("Thu Mar 04 2021")).to.not.be.empty;
-        expect(getByText("Sun Aug 30 2020")).to.not.be.empty;
+                // Assert
+                expect(getByText(uploadedDisplayName)).to.not.be.empty;
+                expect(getByText(expectedDate1)).to.not.be.empty;
+                expect(getByText(expectedDate2)).to.not.be.empty;
+            });
+        });
     });
 
     it("creates RANGE() file filter of RANGE(day,day+1) when only start date is selected", async () => {

--- a/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
+++ b/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import * as React from "react";
 import { Provider } from "react-redux";
 
-import FileMetadataSearchBar, { DATE_RANGE_SEPARATOR, extractDateFromDateString } from "../";
+import FileMetadataSearchBar, { extractDateFromDateString } from "../";
 import FileFilter from "../../../entity/FileFilter";
 import { AnnotationName, TOP_LEVEL_FILE_ANNOTATIONS } from "../../../constants";
 import { initialState, selection } from "../../../state";
@@ -91,12 +91,9 @@ describe("<FileMetadataSearchBar />", () => {
         const uploadedDisplayName =
             TOP_LEVEL_FILE_ANNOTATIONS.find((a) => a.name === AnnotationName.UPLOADED)
                 ?.displayName || "";
-        const date1 = "2021-03-04";
-        const date2 = "2020-08-30";
-        const filter = new FileFilter(
-            AnnotationName.UPLOADED,
-            `${date1}${DATE_RANGE_SEPARATOR}${date2}`
-        );
+        const date1 = "2021-03-04T00:00:00.000Z";
+        const date2 = "2020-08-30T00:00:00.000Z";
+        const filter = new FileFilter(AnnotationName.UPLOADED, `RANGE(${date1},${date2})`);
         const state = {
             ...initialState,
             selection: {
@@ -124,18 +121,18 @@ describe("<FileMetadataSearchBar />", () => {
                 <FileMetadataSearchBar />
             </Provider>
         );
-        const day = 17;
         const date = new Date();
-        const expectedDate = `${date.getFullYear()}-${("0" + (date.getMonth() + 1)).slice(
-            -2
-        )}-${day}`;
-        const expectedRange = `${expectedDate}${DATE_RANGE_SEPARATOR}${expectedDate}`;
+        date.setHours(0);
+        date.setMinutes(0);
+        date.setSeconds(0);
+        date.setMilliseconds(0);
+        const expectedRange = `RANGE(${date.toISOString()},${date.toISOString()})`;
 
         // Act
         fireEvent.click(getByText("File name"));
         fireEvent.click(getByText("Uploaded"));
         fireEvent.click(getByText("Start of date range"));
-        fireEvent.click(getByText(`${day}`));
+        fireEvent.click(getByText(`${date.getDate()}`));
         await logicMiddleware.whenComplete();
 
         // Assert

--- a/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
+++ b/packages/core/components/FileMetadataSearchBar/test/FileMetadataSearchBar.test.tsx
@@ -136,7 +136,7 @@ describe("<FileMetadataSearchBar />", () => {
             </Provider>
         );
         const startDate = new Date();
-        const day = 15; // Arbitrary day of the month that isn't likely to render twice
+        const day = 15; // Arbitrary day of the month that won't show up twice in the Calendar popup
         startDate.setDate(day);
         startDate.setHours(0);
         startDate.setMinutes(0);


### PR DESCRIPTION
Small change to make it so that we can use the new FES API for querying against date/datetime annotations in the Explorer App, which will allow us to remove some code in FES. I was originally going to try and figure out a way to make this a smoother process on the FES side, but this ended up being the least messy solution I could come up with

Basically just replaces the old `YYYY-MM-DD-to-YYYY-MM-DD` filter with `RANGE(YYYY-MM-DD,YYYY-MM-DD)`