### PR TITLE
Remove restriction on sorting on annotations

### DIFF
--- a/packages/core/components/FileList/Header.module.css
+++ b/packages/core/components/FileList/Header.module.css
@@ -31,14 +31,6 @@
 }
 
 .header-cell {
-  cursor: not-allowed;
-}
-
-.header-cell-tooltip {
-  display: flex;
-}
-
-.clickable {
   cursor: pointer;
 }
 

--- a/packages/core/components/FileList/Header.tsx
+++ b/packages/core/components/FileList/Header.tsx
@@ -1,4 +1,4 @@
-import { Icon, TooltipHost } from "@fluentui/react";
+import { Icon } from "@fluentui/react";
 import classNames from "classnames";
 import { map } from "lodash";
 import * as React from "react";
@@ -10,11 +10,8 @@ import FileRow, { CellConfig } from "../../components/FileRow";
 import { interaction, selection } from "../../state";
 import FileListColumnPicker from "./FileListColumnPicker";
 import { SortOrder } from "../../entity/FileSort";
-import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../constants";
 
 import styles from "./Header.module.css";
-
-const SORTABLE_ANNOTATIONS = TOP_LEVEL_FILE_ANNOTATIONS.map((a) => a.displayName).join(",");
 
 /**
  * The FileList table header. Its cells are determined by the annotations the user has selected to display. It is rendered directly into the virtualized list within the FileList component
@@ -42,35 +39,22 @@ function Header(
 
     const headerCells: CellConfig[] = map(columnAnnotations, (annotation) => {
         const isSortedColumn = sortColumn?.annotationName === annotation.name;
-        const isFileAttribute = TOP_LEVEL_FILE_ANNOTATION_NAMES.includes(annotation.name);
         return {
             columnKey: annotation.name, // needs to match the value used to produce `column`s passed to the `useResizableColumns` hook
             displayValue: (
                 <span
                     className={classNames(styles.headerCell, {
-                        [styles.clickable]: isFileAttribute,
                         [styles.bold]: isSortedColumn,
                     })}
-                    onClick={() =>
-                        isFileAttribute && dispatch(selection.actions.sortColumn(annotation.name))
-                    }
+                    onClick={() => dispatch(selection.actions.sortColumn(annotation.name))}
                 >
-                    <TooltipHost
-                        hostClassName={styles.headerCellTooltip}
-                        content={
-                            isFileAttribute
-                                ? undefined
-                                : `${annotation.displayName} is not sortable. Try one of ${SORTABLE_ANNOTATIONS}.`
-                        }
-                    >
-                        <span className={styles.headerTitle}>{annotation.displayName}</span>
-                        {isSortedColumn &&
-                            (sortColumn?.order === SortOrder.DESC ? (
-                                <Icon className={styles.sortIcon} iconName="ChevronDown" />
-                            ) : (
-                                <Icon className={styles.sortIcon} iconName="ChevronUp" />
-                            ))}
-                    </TooltipHost>
+                    <span className={styles.headerTitle}>{annotation.displayName}</span>
+                    {isSortedColumn &&
+                        (sortColumn?.order === SortOrder.DESC ? (
+                            <Icon className={styles.sortIcon} iconName="ChevronDown" />
+                        ) : (
+                            <Icon className={styles.sortIcon} iconName="ChevronUp" />
+                        ))}
                 </span>
             ),
             width: columnWidths[annotation.name] || 1 / columnAnnotations.length,

--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -119,10 +119,14 @@ export default class FileExplorerURL {
         );
 
         let sortColumn = undefined;
+        const annotationNameSet = new Set([
+            ...annotations.map((annotation) => annotation.name),
+            ...TOP_LEVEL_FILE_ANNOTATION_NAMES,
+        ]);
         if (parsedURL.sort) {
-            if (!TOP_LEVEL_FILE_ANNOTATION_NAMES.includes(parsedURL.sort.annotationName)) {
+            if (!annotationNameSet.has(parsedURL.sort.annotationName)) {
                 throw new ValueError(
-                    `Unable to decode FileExplorerURL, sort column must be one of ${TOP_LEVEL_FILE_ANNOTATION_NAMES}`
+                    `Unable to decode FileExplorerURL, couldn't find Annotation(${parsedURL.sort.annotationName})`
                 );
             }
             if (!Object.values(SortOrder).includes(parsedURL.sort.order)) {
@@ -147,10 +151,6 @@ export default class FileExplorerURL {
         }
 
         const hierarchyDepth = parsedURL.groupBy.length;
-        const annotationNameSet = new Set([
-            ...annotations.map((annotation) => annotation.name),
-            ...TOP_LEVEL_FILE_ANNOTATION_NAMES,
-        ]);
         return {
             hierarchy: parsedURL.groupBy.map((annotationName) => {
                 if (!annotationNameSet.has(annotationName)) {


### PR DESCRIPTION
Sorting on annotations (non file-property data, so anything that isn't filename, fileid, filesize, etc.) has been disabled because performance when doing so was so slow it didn't seem worth it to allow it. However, with the recent performance upgrades the hope is that we can enable this feature. Testing against a local FES that was pointed at staging made it seem possible to sort on annotations without performance becoming unbearable.