### PR TITLE
Feature/swe 224 prevent unnecessary calls to files resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14468,15 +14468,15 @@
       }
     },
     "node_modules/react-window-infinite-loader": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-window-infinite-loader/-/react-window-infinite-loader-1.0.7.tgz",
-      "integrity": "sha512-wg3LWkUpG21lhv+cZvNy+p0+vtclZw+9nP2vO6T9PKT50EN1cUq37Dq6FzcM38h/c2domE0gsUhb6jHXtGogAA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-window-infinite-loader/-/react-window-infinite-loader-1.0.8.tgz",
+      "integrity": "sha512-907ZLAiZZfBHuZyiY0V7uiSL4P/rI6UQyCF9wES1cDWTeyNLgGLaxu+BZkcUW3R5tSCQcbCcWBl0jVIpYzrKGQ==",
       "engines": {
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0"
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react/node_modules/object-assign": {
@@ -17606,7 +17606,7 @@
     },
     "packages/desktop": {
       "name": "fms-file-explorer-desktop",
-      "version": "6.1.0-0",
+      "version": "6.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@aics/frontend-insights": "0.2.x",
@@ -28544,9 +28544,9 @@
       }
     },
     "react-window-infinite-loader": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-window-infinite-loader/-/react-window-infinite-loader-1.0.7.tgz",
-      "integrity": "sha512-wg3LWkUpG21lhv+cZvNy+p0+vtclZw+9nP2vO6T9PKT50EN1cUq37Dq6FzcM38h/c2domE0gsUhb6jHXtGogAA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-window-infinite-loader/-/react-window-infinite-loader-1.0.8.tgz",
+      "integrity": "sha512-907ZLAiZZfBHuZyiY0V7uiSL4P/rI6UQyCF9wES1cDWTeyNLgGLaxu+BZkcUW3R5tSCQcbCcWBl0jVIpYzrKGQ==",
       "requires": {}
     },
     "read-config-file": {

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -105,9 +105,11 @@ export default function FileList(props: FileListProps) {
                 ref={measuredNodeRef}
             >
                 {/* 
-                    Avoid rendering a flat list which causes the <InfiniteLoader />
-                    to request for files unnecessarily when the root file list,
-                    instead wait a few milliseconds for the height to be either measured
+                    When this component isRoot the height is measured. It takes
+                    a few milliseconds for that to happen along with a re-render, but
+                    by then the <InfiniteLoader /> used here will already have made a 
+                    request for files based on that height that it didn't need to
+                    if it had just waited until the measured height was present.
                  */}
                 {height !== 0 && (
                     <InfiniteLoader


### PR DESCRIPTION
The `<InfiniteLoader />` component has been requesting for a small batch of files upon the initial render of the `<FileList />` component (which represents the list of files seen in the UI). Nearly immediately after this request the height of the component is measured and given to the `<InfiniteLoader />` causing it to make another request for another batch of files that contains the original batch as a subset. This is unnecessary for two reasons:
1) Until the files request has completed, the `<InfiniteLoader />` is told that the original subset of files requested has not loaded (which is true), but what it is really asking is "should I, the component, ask for these files?" which is not necessarily the same. For example, say the batch of files initially fetched is from index 0 - 13 and the second batch is 0 - 53. The indexes 0 - 13 is entirely contained within the latter and do not need re-fetched, but we were essentially saying "even though those files will shortly be available, re-request them.". Instead, the component will now be told to ask for files that are both not being fetched and not fetched already. Note: reason/solution 2 solves this initial duplicate, but does not solve future ones caused by scrolling which is why both combined are helpful.
2) The component does not need to do that initial request at all, it can just wait until the height is measured or calculated. The measured height is used in the root `<FileList />` case which is the first view you see when you open the app as opposed to a `<FileList />` that is within a folder otherwise it uses a calculated height based on the total count of files represented by the list. The measured height calculation and re-render is very quick so just waiting that out doesn't seem to cause any delays or problems visually. The calculated height would likely delay the render if we waited for it before rendering the list so I gave it a default.

**Testing**
Checking out the network calls locally made to FES and comparing the startIndex, endIndex, limit, & offset in comparison to each other to see how much overlap and duplication is happening. A few (< 10) files may get re-fetched due to dynamic pagination and over-fetching, but for the most part I can confirm files are less likely to get fetched > 1 time. The initial fetch is also not present & it doesn't seem to have affected the visuals of a file list being rendered (i.e. I don't notice any additional delay).

**Note**
I did look into using a fixed page size when paging to try to further reduce our requests to the File Explorer Service (FES), but it started to look a lot like what we are already doing so likely not worth doing.