### PR TITLE
[SWE-223] Remove blocking totalCount() call when loading new <FileList>'s

### DIFF
--- a/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
+++ b/packages/core/components/DirectoryTree/useDirectoryHierarchy.tsx
@@ -129,28 +129,12 @@ const useDirectoryHierarchy = (
         async function getContent() {
             if (isLeaf || hierarchy.length === 0) {
                 // if we're at the top or bottom of the hierarchy, render a FileList
-                try {
-                    const totalCount = await fileSet.fetchTotalCount();
-                    if (!cancel) {
-                        dispatch(
-                            receiveContent(
-                                <FileList
-                                    fileSet={fileSet}
-                                    isRoot={isRoot}
-                                    sortOrder={sortOrder}
-                                    totalCount={totalCount}
-                                />
-                            )
-                        );
-                    }
-                } catch (e) {
-                    console.error(
-                        `Failed to fetch the total number of documents belonging to ${fileSet.toString()}`,
-                        e
+                if (!cancel) {
+                    dispatch(
+                        receiveContent(
+                            <FileList fileSet={fileSet} isRoot={isRoot} sortOrder={sortOrder} />
+                        )
                     );
-                    if (!cancel) {
-                        dispatch(setError(e as Error, isRoot));
-                    }
                 }
             } else {
                 // otherwise, there's more hierarchy to show

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -28,7 +28,6 @@ interface FileListProps {
     isRoot: boolean;
     rowHeight?: number; // how tall each row of the list will be, in px
     sortOrder: number;
-    totalCount?: number;
 }
 
 const DEFAULTS = {
@@ -43,11 +42,9 @@ const MAX_NON_ROOT_HEIGHT = 300;
  * itself out to be 100% the height and width of its parent.
  */
 export default function FileList(props: FileListProps) {
-    const { className, fileSet, isRoot, rowHeight, sortOrder, totalCount } = defaults(
-        {},
-        props,
-        DEFAULTS
-    );
+    const { className, fileSet, isRoot, rowHeight, sortOrder } = defaults({}, props, DEFAULTS);
+
+    const [totalCount, setTotalCount] = React.useState<number | null>(null);
 
     const onSelect = useFileSelector(fileSet, sortOrder);
     const fileSelection = useSelector(selection.selectors.getFileSelection);
@@ -62,7 +59,7 @@ export default function FileList(props: FileListProps) {
     const [measuredNodeRef, measuredHeight, measuredWidth] = useLayoutMeasurements<
         HTMLDivElement
     >();
-    const dataDrivenHeight = rowHeight * totalCount + 3 * rowHeight; // adding three additional rowHeights leaves room for the header + horz. scroll bar
+    const dataDrivenHeight = rowHeight * (totalCount || DEFAULT_TOTAL_COUNT) + 3 * rowHeight; // adding three additional rowHeights leaves room for the header + horz. scroll bar
     const calculatedHeight = Math.min(MAX_NON_ROOT_HEIGHT, dataDrivenHeight);
     const height = isRoot ? measuredHeight : calculatedHeight;
 
@@ -95,6 +92,19 @@ export default function FileList(props: FileListProps) {
         }
     }, [fileSelection, fileSet, height, rowHeight]);
 
+    // Get a count of all files in the FileList, but don't wait on it
+    React.useEffect(() => {
+        let cancel = false;
+        fileSet.fetchTotalCount().then((count) => {
+            if (!cancel) {
+                setTotalCount(count);
+            }
+        });
+        return () => {
+            cancel = true;
+        };
+    }, [fileSet]);
+
     return (
         <div className={classNames(styles.container, className)}>
             <div
@@ -111,7 +121,7 @@ export default function FileList(props: FileListProps) {
                         fileSet.fetchFileRange,
                         DEBOUNCE_WAIT_FOR_DATA_FETCHING
                     )}
-                    itemCount={totalCount}
+                    itemCount={totalCount || DEFAULT_TOTAL_COUNT}
                 >
                     {({ onItemsRendered, ref: innerRef }) => {
                         const callbackRef = (instance: FixedSizeList | null) => {
@@ -133,7 +143,7 @@ export default function FileList(props: FileListProps) {
                                 }}
                                 itemSize={rowHeight} // row height
                                 height={height} // height of the list itself; affects number of rows rendered at any given time
-                                itemCount={totalCount}
+                                itemCount={totalCount || DEFAULT_TOTAL_COUNT}
                                 onItemsRendered={onItemsRendered}
                                 outerElementType={Header}
                                 outerRef={outerRef}
@@ -146,7 +156,9 @@ export default function FileList(props: FileListProps) {
                     }}
                 </InfiniteLoader>
             </div>
-            <p className={styles.rowCountDisplay}>{totalCount} files</p>
+            <p className={styles.rowCountDisplay}>
+                {totalCount ? `${totalCount} files` : "Counting files..."}
+            </p>
         </div>
     );
 }

--- a/packages/core/components/FileList/test/FileList.test.tsx
+++ b/packages/core/components/FileList/test/FileList.test.tsx
@@ -1,0 +1,35 @@
+import FileList from "../index";
+import { render } from "@testing-library/react";
+import * as React from "react";
+import FileSet from "../../../entity/FileSet";
+import { expect } from "chai";
+import { Provider } from "react-redux";
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { initialState } from "../../../state";
+import FileService from "../../../services/FileService";
+import { createSandbox } from "sinon";
+
+describe("<FileList />", () => {
+    it("Renders 'Loading files...' when files have not yet loaded", async () => {
+        const state = mergeState(initialState, {});
+        const { store } = configureMockStore({ state });
+
+        const sandbox = createSandbox();
+        const fileService = new FileService();
+        sandbox.replace(fileService, "getCountOfMatchingFiles", () => Promise.resolve(999));
+        const fileSet = new FileSet({ fileService });
+
+        const { findByText, queryByText } = render(
+            <Provider store={store}>
+                <FileList fileSet={fileSet} isRoot={false} sortOrder={4} />
+            </Provider>
+        );
+
+        // This should be present on the initial render and disappear once the file info comes in
+        expect(queryByText("Counting files...")).to.exist;
+
+        // Wait for the fileService call to return, then check for updated list length display
+        await findByText("999 files");
+        expect(queryByText("Counting files...")).to.not.exist;
+    });
+});

--- a/packages/core/components/FileList/test/FileList.test.tsx
+++ b/packages/core/components/FileList/test/FileList.test.tsx
@@ -10,7 +10,7 @@ import FileService from "../../../services/FileService";
 import { createSandbox } from "sinon";
 
 describe("<FileList />", () => {
-    it("Renders 'Loading files...' when files have not yet loaded", async () => {
+    it("Calls getCountOfMatchingFiles() on mount and properly updates state afterwards", async () => {
         const state = mergeState(initialState, {});
         const { store } = configureMockStore({ state });
 
@@ -25,7 +25,7 @@ describe("<FileList />", () => {
             </Provider>
         );
 
-        // This should be present on the initial render and disappear once the file info comes in
+        // This should be present on the initial render and get replaced when the query returns
         expect(queryByText("Counting files...")).to.exist;
 
         // Wait for the fileService call to return, then check for updated list length display


### PR DESCRIPTION
[Ticket here](https://aicsjira.corp.alleninstitute.org/browse/SWE-223).
#### Context
See these folders in the File Explorer, e.g. AICS-0?
![image](https://user-images.githubusercontent.com/65628854/189240905-6649e71d-502d-47ca-b340-e43e74cad849.png)
Right now, opening them up and seeing their file contents takes an extra long time. This isn't just because some of our Mongo queries are slow, but rather that we're waiting on queries that don't need to be waited on. The culprit is that little count of files in the bottom right of the file list. We first wait to figure out what that number should be, and _then_ we begin asking for files. Problem is, counting those files can take a long time on its own (think 10+ seconds), and we want people to be able to look at files instead of staring at loading icons.

Turns out we can shoot off both the getfiles() and the count() queries at (roughly) the same time, and that results in having a (roughly) twice as fast display of the `<FileList>` contents, which is what this ticket aims to accomplish. In combination with other ongoing work to improve the speed of the queries themselves, this should make the File Explorer App feel more responsive.

#### Changes
* Moved the query for determining `<FileList>`'s file count into an asynchronous function call that is triggered when the component mounts

#### Testing
I added one new test in [packages/core/components/FileList/test/FileList.test.tsx](https://github.com/AllenInstitute/aics-fms-file-explorer-app/compare/feature/SWE-223_make_count_calls_parallel?expand=1#diff-a9b35d6758685a6a6ba1654a62c0239e03629c07404b8209126e7ba23fff7fca) for ensuring the count() query is triggered when `<FileList>` mounts and properly updates state once it returns a value. Peeped at the "Network" tab in the app to get an idea of how much faster the file list renders are now