### PR TITLE
Feature/swe 278 remove total count

### DIFF
--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -118,7 +118,6 @@ export default class FileSet {
                 this.cache.set(startIndexOfPage + i, response.data[i]);
             }
 
-            this.totalFileCount = response.totalCount;
             return response.data;
         } finally {
             // Clear the previously saved indexes as they are no longer loading

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -58,7 +58,6 @@ describe("FileSet", () => {
                         data: files.slice(1, 4),
                         offset: 0,
                         responseType: "SUCCESS",
-                        totalCount: fileIds.length,
                     })
                 )
             );
@@ -149,7 +148,6 @@ describe("FileSet", () => {
                     data: files.slice(),
                     offset: 0,
                     responseType: "SUCCESS",
-                    totalCount: fileIds.length,
                 })
             )
         );

--- a/packages/core/entity/FileSet/test/FileSet.test.ts
+++ b/packages/core/entity/FileSet/test/FileSet.test.ts
@@ -56,7 +56,6 @@ describe("FileSet", () => {
                 Promise.resolve(
                     new RestServiceResponse({
                         data: files.slice(1, 4),
-                        hasMore: false,
                         offset: 0,
                         responseType: "SUCCESS",
                         totalCount: fileIds.length,
@@ -148,7 +147,6 @@ describe("FileSet", () => {
             Promise.resolve(
                 new RestServiceResponse({
                     data: files.slice(),
-                    hasMore: false,
                     offset: 0,
                     responseType: "SUCCESS",
                     totalCount: fileIds.length,

--- a/packages/core/entity/RestServiceResponse/index.ts
+++ b/packages/core/entity/RestServiceResponse/index.ts
@@ -2,7 +2,6 @@ export interface Response<T> {
     data: T[];
     offset: number;
     responseType: string;
-    totalCount: number;
 }
 
 /**

--- a/packages/core/entity/RestServiceResponse/index.ts
+++ b/packages/core/entity/RestServiceResponse/index.ts
@@ -1,6 +1,5 @@
 export interface Response<T> {
     data: T[];
-    hasMore: boolean;
     offset: number;
     responseType: string;
     totalCount: number;
@@ -21,19 +20,11 @@ export default class RestServiceResponse<T = any> {
         return this.response.data;
     }
 
-    get hasMore(): boolean {
-        return this.response.hasMore;
-    }
-
     get offset(): number {
         return this.response.offset;
     }
 
     get responseType(): string {
         return this.response.responseType;
-    }
-
-    get totalCount(): number {
-        return this.response.totalCount;
     }
 }

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -66,7 +66,7 @@ interface SelectionResult {
  * Service responsible for fetching file related metadata.
  */
 export default class FileService extends HttpServiceBase {
-    private static readonly ENDPOINT_VERSION = "2.0";
+    private static readonly ENDPOINT_VERSION = "3.0";
     public static readonly BASE_FILES_URL = `file-explorer-service/${FileService.ENDPOINT_VERSION}/files`;
     public static readonly BASE_FILE_COUNT_URL = `${FileService.BASE_FILES_URL}/count`;
     public static readonly SELECTION_AGGREGATE_URL = `${FileService.BASE_FILES_URL}/selection/aggregate`;


### PR DESCRIPTION
[Per this work in the File Explorer Service](https://aicsbitbucket.corp.alleninstitute.org/projects/SW/repos/file-explorer-service/pull-requests/118/overview) the `totalCount` property and `hasMore` property should be avoided since calculating them requires extra work on the server that need not happen.

**Testing**
Tested by opening the application and running through the usual features of the application to see if they behave as expected as well as double checking the responses look correct.