### PR TITLE
Clean up related to SWE-397

### DIFF
--- a/packages/core/services/CsvService/index.ts
+++ b/packages/core/services/CsvService/index.ts
@@ -1,9 +1,14 @@
 import HttpServiceBase, { ConnectionConfig } from "../HttpServiceBase";
 import FileDownloadService, { DownloadResult } from "../FileDownloadService";
-import { SelectionRequest } from "../FileService";
+import { Selection } from "../FileService";
 
 interface CsvServiceConfig extends ConnectionConfig {
     downloadService: FileDownloadService;
+}
+
+export interface CsvManifestRequest {
+    annotations: string[];
+    selections: Selection[];
 }
 
 /**
@@ -22,7 +27,7 @@ export default class CsvService extends HttpServiceBase {
     }
 
     public downloadCsv(
-        selectionRequest: SelectionRequest,
+        selectionRequest: CsvManifestRequest,
         manifestDownloadId: string
     ): Promise<DownloadResult> {
         const stringifiedPostBody = JSON.stringify(selectionRequest);

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -52,12 +52,11 @@ export interface Selection {
     };
 }
 
-export interface SelectionRequest {
-    annotations: string[];
+interface SelectionAggregationRequest {
     selections: Selection[];
 }
 
-interface SelectionResult {
+interface SelectionAggregationResult {
     count: number;
     size: number;
 }
@@ -91,13 +90,18 @@ export default class FileService extends HttpServiceBase {
         return response.data[0];
     }
 
-    public async getAggregateInformation(fileSelection: FileSelection): Promise<SelectionResult> {
+    public async getAggregateInformation(
+        fileSelection: FileSelection
+    ): Promise<SelectionAggregationResult> {
         const selections = fileSelection.toCompactSelectionList();
-        const postBody: SelectionRequest = { annotations: [], selections };
+        const postBody: SelectionAggregationRequest = { selections };
         const requestUrl = `${this.baseUrl}/${FileService.SELECTION_AGGREGATE_URL}${this.pathSuffix}`;
         console.log(`Requesting aggregate results of matching files ${postBody}`);
 
-        const response = await this.post<SelectionResult>(requestUrl, JSON.stringify(postBody));
+        const response = await this.post<SelectionAggregationResult>(
+            requestUrl,
+            JSON.stringify(postBody)
+        );
 
         // data is always an array, this endpoint should always return an array of length 1
         if (response.data.length !== 1) {

--- a/packages/core/services/FileService/index.ts
+++ b/packages/core/services/FileService/index.ts
@@ -29,9 +29,6 @@ export interface FmsFile {
     file_path: string;
     file_size: number;
     uploaded: string;
-    positions?: { id: number }[]; // TODO: Add Ticket for this
-    channels?: { id: number }[]; // TODO: Add Ticket for this
-    times?: { id: number }[]; // TODO: Add Ticket for this
     thumbnail?: string;
 }
 

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -35,13 +35,13 @@ import {
     UPDATE_COLLECTION,
 } from "./actions";
 import * as interactionSelectors from "./selectors";
-import CsvService from "../../services/CsvService";
+import CsvService, { CsvManifestRequest } from "../../services/CsvService";
 import { DownloadResolution } from "../../services/FileDownloadService";
 import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileSet from "../../entity/FileSet";
 import NumericRange from "../../entity/NumericRange";
 import { CreateDatasetRequest, Dataset } from "../../services/DatasetService";
-import { SelectionRequest, FmsFile } from "../../services/FileService";
+import { FmsFile } from "../../services/FileService";
 import {
     ExecutableEnvCancellationToken,
     SystemDefaultAppLocation,
@@ -147,14 +147,11 @@ const downloadManifest = createLogic({
                 )
             );
 
-            const selectionRequest: SelectionRequest = {
+            const request: CsvManifestRequest = {
                 annotations: annotations.map((annotation) => annotation.name),
                 selections,
             };
-            const result = await csvService.downloadCsv(
-                selectionRequest,
-                manifestDownloadProcessId
-            );
+            const result = await csvService.downloadCsv(request, manifestDownloadProcessId);
 
             if (result.resolution === DownloadResolution.CANCELLED) {
                 dispatch(removeStatus(manifestDownloadProcessId));


### PR DESCRIPTION
**Context:**
As part of tackling SWE-397, I cleaned out some long unused code. See https://aicsbitbucket.corp.alleninstitute.org/projects/SW/repos/file-explorer-service/pull-requests/124/overview. These are the corresponding client changes.

**This changeset:**
1. Because I removed the unused "histogram" feature from the selection aggregation endpoint, it no longer makes sense to pass annotations to include in that histogram to the endpoint. FWIW, it had always been hardcoded to an empty list.
2. Not strictly related, but while I was here: remove some "image model" related properties from the `FmsFile` interface. Those no longer exist in our data schema; see the most up-to-date JSON schema: https://github.com/aics-int/fms-mongo-etl/blob/main/fms_mongo_etl/service/validation_schemas/file.py.
3. Prevent tests for `<AggregateInfoBox />` from hitting the production `file-explorer-service`.

**Testing:**
1. Existing automated tests passing (and unchanged).
2. Manual testing against a locally running version of https://aicsbitbucket.corp.alleninstitute.org/projects/SW/repos/file-explorer-service/pull-requests/124/overview.