### PR TITLE
[SWE-706] Add payload as properties

### DIFF
--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -59,7 +59,7 @@ const collectPlatformDependentServices = memoize(
     })
 );
 
-const frontendInsightsMiddleware = reduxMiddleware(frontendInsights);
+const frontendInsightsMiddleware = reduxMiddleware(frontendInsights, { useActionAsProperties: true });
 const store = createReduxStore({
     middleware: [frontendInsightsMiddleware],
     persistedConfig: persistentConfigService.getAll(),


### PR DESCRIPTION
This will cause the redux action payload to be spread across the event metrics as properties, hopefully informing us of specific annotation usage