### PR TITLE
[SWE-752] Use AllenCellSoftware electron builder action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 16
 
       - name: Build/release Electron app
-        uses: GabeMedrash/action-electron-builder@fms-file-explorer
+        uses: AllenCellSoftware/action-electron-builder@fms-file-explorer
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 16
 
       - name: Build/release Electron app
-        uses: GabeMedrash/action-electron-builder@fms-file-explorer
+        uses: AllenCellSoftware/action-electron-builder@fms-file-explorer
         env:
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
         with:


### PR DESCRIPTION
Updates the integration and release actions to pull from `AllenCellSoftware/action-electron-builder` rather than `GabeMedrash/action-electron-builder`. Just in case Gabe ever feels like deleting his repo.