### PR TITLE
Feature/swe 735 help tab

### DIFF
--- a/packages/core/App.tsx
+++ b/packages/core/App.tsx
@@ -11,6 +11,7 @@ import FileDetails from "./components/FileDetails";
 import FileExplorerURLBar from "./components/FileExplorerURLBar";
 import HeaderRibbon from "./components/HeaderRibbon";
 import StatusMessage from "./components/StatusMessage";
+import TutorialTooltip from "./components/TutorialTooltip";
 import { FileExplorerServiceBaseUrl } from "./constants";
 import { interaction, metadata, selection } from "./state";
 import { PlatformDependentServices } from "./state/interaction/actions";
@@ -82,6 +83,7 @@ export default function App(props: AppProps) {
             <ContextMenu key={useSelector(interaction.selectors.getContextMenuKey)} />
             <StatusMessage />
             <Modal />
+            <TutorialTooltip />
         </div>
     );
 }

--- a/packages/core/components/AggregateInfoBox/test/AggregateInfoBox.test.tsx
+++ b/packages/core/components/AggregateInfoBox/test/AggregateInfoBox.test.tsx
@@ -69,8 +69,8 @@ describe("<AggregateInfoBox />", () => {
         );
 
         // Assert
-        expect(() => getAllByTestId("aggregate-info-box-spinner")).to.throw;
-        expect(() => getByText("Total Files")).to.throw;
+        expect(() => getAllByTestId("aggregate-info-box-spinner")).to.throw();
+        expect(() => getByText("Total Files")).to.throw();
     });
 
     it("renders loading spinner when data has yet to load", async () => {

--- a/packages/core/components/AnnotationHierarchy/index.tsx
+++ b/packages/core/components/AnnotationHierarchy/index.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useSelector } from "react-redux";
 
 import DnDList from "../../components/DnDList";
+import Tutorial from "../../entity/Tutorial";
 import HierarchyListItem from "./HierarchyListItem";
 import * as annotationSelectors from "../AnnotationSidebar/selectors";
 
@@ -24,7 +25,7 @@ export default function AnnotationHierarchy(props: AnnotationHierarchyProps) {
     const annotationHierarchyListItems = useSelector(annotationSelectors.getHierarchyListItems);
 
     return (
-        <div className={classNames(styles.root, className)}>
+        <div className={classNames(styles.root, className)} id={Tutorial.ANNOTATION_HIERARCHY_ID}>
             <h3 className={styles.title}>Annotation Hierarchy</h3>
             <h6 className={styles.description}>
                 Files will be grouped by the following annotations

--- a/packages/core/components/AnnotationList/index.tsx
+++ b/packages/core/components/AnnotationList/index.tsx
@@ -7,8 +7,9 @@ import AnnotationListItem from "./AnnotationListItem";
 import DnDList from "../../components/DnDList";
 import { DnDListDividers } from "../../components/DnDList/DnDList";
 import SvgIcon from "../../components/SvgIcon";
-import * as annotationSelectors from "../AnnotationSidebar/selectors";
+import Tutorial from "../../entity/Tutorial";
 import selection from "../../state/selection";
+import * as annotationSelectors from "../AnnotationSidebar/selectors";
 
 import styles from "./AnnotationList.module.css";
 
@@ -93,7 +94,7 @@ export default function AnnotationList(props: AnnotationListProps) {
         <div className={classNames(styles.root, props.className)}>
             <h3 className={styles.title}>Available Annotations</h3>
             <h6 className={styles.description}>Drag any annotation to the box above</h6>
-            <div className={styles.listContainer}>
+            <div className={styles.listContainer} id={Tutorial.ANNOTATION_LIST_ID}>
                 <div className={styles.searchBox}>
                     <SvgIcon
                         className={styles.searchIcon}

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -6,6 +6,7 @@ import { interaction, selection } from "../../state";
 import AggregateInfoBox from "../AggregateInfoBox";
 import FilterDisplayBar from "../FilterDisplayBar";
 import FileSet from "../../entity/FileSet";
+import Tutorial from "../../entity/Tutorial";
 import RootLoadingIndicator from "./RootLoadingIndicator";
 import useDirectoryHierarchy from "./useDirectoryHierarchy";
 import FileMetadataSearchBar from "../FileMetadataSearchBar";
@@ -77,7 +78,12 @@ export default function DirectoryTree(props: FileListProps) {
             <RootLoadingIndicator visible={isLoading} />
             <FilterDisplayBar className={styles.filterDisplayBar} classNameHidden={styles.hidden} />
             <FileMetadataSearchBar />
-            <ul className={styles.scrollContainer} role="tree" aria-multiselectable="true">
+            <ul
+                className={styles.scrollContainer}
+                role="tree"
+                aria-multiselectable="true"
+                id={Tutorial.FILE_LIST_ID}
+            >
                 {!error && content}
                 {error && (
                     <aside className={styles.errorMessage}>

--- a/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationList.test.tsx
@@ -100,7 +100,7 @@ describe("<FileAnnotationList />", () => {
             );
 
             // Assert
-            expect(() => getByText("File path (Local)")).to.throw;
+            expect(() => getByText("File path (Local)")).to.throw();
             ["File path (Canonical)", filePath].forEach((cellText) => {
                 expect(getByText(cellText)).to.not.be.undefined;
             });

--- a/packages/core/components/FileExplorerURLBar/index.tsx
+++ b/packages/core/components/FileExplorerURLBar/index.tsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import getContextMenuItems from "../ContextMenu/items";
 import SvgIcon from "../../components/SvgIcon";
 import FileExplorerURL from "../../entity/FileExplorerURL";
+import Tutorial from "../../entity/Tutorial";
 import { ERROR_ICON_PATH_DATA } from "../../icons";
 import { interaction, metadata, selection } from "../../state";
 
@@ -100,7 +101,7 @@ function FileExplorerURLBar(props: FileExplorerURLBarProps) {
 
     return (
         <div className={classNames(styles.container, props.className)}>
-            <form className={styles.urlForm} onSubmit={onSubmit}>
+            <form className={styles.urlForm} id={Tutorial.URL_BOX_ID} onSubmit={onSubmit}>
                 <TextField
                     borderless
                     disabled={isLoading}
@@ -122,6 +123,7 @@ function FileExplorerURLBar(props: FileExplorerURLBarProps) {
                 <TooltipHost content={isCopied ? "Copied to clipboard!" : undefined}>
                     <IconButton
                         className={styles.button}
+                        id={Tutorial.COPY_URL_BUTTON_ID}
                         iconProps={{ iconName: "link" }}
                         onClick={onCopy}
                     />

--- a/packages/core/components/FileList/Header.tsx
+++ b/packages/core/components/FileList/Header.tsx
@@ -7,9 +7,10 @@ import { useSelector, useDispatch } from "react-redux";
 import { ContextMenuItem } from "../ContextMenu";
 import getContextMenuItems from "../ContextMenu/items";
 import FileRow, { CellConfig } from "../../components/FileRow";
+import { SortOrder } from "../../entity/FileSort";
+import Tutorial from "../../entity/Tutorial";
 import { interaction, selection } from "../../state";
 import FileListColumnPicker from "./FileListColumnPicker";
-import { SortOrder } from "../../entity/FileSort";
 import { TOP_LEVEL_FILE_ANNOTATIONS, TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../constants";
 
 import styles from "./Header.module.css";
@@ -101,7 +102,7 @@ function Header(
 
     return (
         <div ref={ref} {...rest}>
-            <div className={styles.headerWrapper}>
+            <div className={styles.headerWrapper} id={Tutorial.COLUMN_HEADERS_ID}>
                 <FileRow
                     cells={headerCells}
                     className={styles.header}

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -8,6 +8,7 @@ import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
 import FileSet from "../../entity/FileSet";
+import Tutorial from "../../entity/Tutorial";
 import Header from "./Header";
 import LazilyRenderedRow from "./LazilyRenderedRow";
 import { selection } from "../../state";
@@ -180,6 +181,7 @@ export default function FileList(props: FileListProps) {
                 style={{
                     height: isRoot ? undefined : `${calculatedHeight}px`,
                 }}
+                id={Tutorial.FILE_LIST_ID}
                 ref={measuredNodeRef}
             >
                 {content}

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -8,7 +8,6 @@ import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
 import FileSet from "../../entity/FileSet";
-import Tutorial from "../../entity/Tutorial";
 import Header from "./Header";
 import LazilyRenderedRow from "./LazilyRenderedRow";
 import { selection } from "../../state";
@@ -181,7 +180,6 @@ export default function FileList(props: FileListProps) {
                 style={{
                     height: isRoot ? undefined : `${calculatedHeight}px`,
                 }}
-                id={Tutorial.FILE_LIST_ID}
                 ref={measuredNodeRef}
             >
                 {content}

--- a/packages/core/components/FileMetadataSearchBar/index.tsx
+++ b/packages/core/components/FileMetadataSearchBar/index.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AnnotationName, TOP_LEVEL_FILE_ANNOTATIONS } from "../../constants";
 import { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileFilter from "../../entity/FileFilter";
+import Tutorial from "../../entity/Tutorial";
 import { selection } from "../../state";
 import { getFileAttributeFilter } from "../../state/selection/selectors";
 
@@ -181,7 +182,7 @@ export default function FileMetadataSearchBar() {
     }
 
     return (
-        <div className={styles.searchBarContainer}>
+        <div className={styles.searchBarContainer} id={Tutorial.FILE_ATTRIBUTE_FILTER_ID}>
             <Dropdown
                 className={styles.fileAttributeSelector}
                 options={FILE_ATTRIBUTE_OPTIONS}

--- a/packages/core/components/FilterDisplayBar/test/FilterDisplayBar.test.tsx
+++ b/packages/core/components/FilterDisplayBar/test/FilterDisplayBar.test.tsx
@@ -137,7 +137,7 @@ describe("<FilterDisplayBar />", () => {
         // now you don't
         const clearButton = await findByRole("button", { exact: false, name: "Clear" });
         fireEvent.click(clearButton);
-        expect(() => getByText(/^Cell Line/)).to.throw;
+        expect(() => getByText(/^Cell Line/)).to.throw();
     });
 
     it("presents the display value of a filter", async () => {

--- a/packages/core/components/HeaderRibbon/HeaderRibbon.module.css
+++ b/packages/core/components/HeaderRibbon/HeaderRibbon.module.css
@@ -128,11 +128,11 @@ h5.control-group {
     background-color: white;
     border-radius: 48px;
     height: 48px;
-    margin-left: 3.75%;
-    margin-top: 1.2%;
-    position: absolute;
-    top: 0;
+    top: calc(-50% - 24px);
+    left: calc(50% - 24px);
+    position: relative;
     width: 48px;
+    z-index: 1;
 }
 
 .help-button-container {
@@ -147,16 +147,8 @@ h5.control-group {
     background-color: white;
 }
 
-.help-button-container:hover > .help-button-circle {
-    background-color: var(--secondary-ribbon-color);
-}
-
 .help-button-container i {
     color: var(--secondary-ribbon-color);
-}
-
-.help-button-container:hover i {
-    color: white;
 }
 
 .help-button {
@@ -167,6 +159,7 @@ h5.control-group {
     height: 100%;
     padding: calc(var(--ribbon-header-height) - 30px);
     width: 100%;
+    z-index: 2;
 }
 
 .help-button > span {

--- a/packages/core/components/HeaderRibbon/HeaderRibbon.module.css
+++ b/packages/core/components/HeaderRibbon/HeaderRibbon.module.css
@@ -59,6 +59,11 @@ h5.control-group {
     white-space: nowrap;
 }
 
+.control-group.filler {
+    max-width: 37.5%;
+    min-width: 0;
+}
+
 .control-group-input-group {
     width: 100%;
 }
@@ -113,4 +118,61 @@ h5.control-group {
   font-size: 12px;
   margin-left: 0.5em;
   margin-top: 0.05em;
+}
+
+.smaller-control-group {
+    width: 12.5%;
+}
+
+.help-button-circle {
+    background-color: white;
+    border-radius: 48px;
+    height: 48px;
+    margin-left: 3.75%;
+    margin-top: 1.2%;
+    position: absolute;
+    top: 0;
+    width: 48px;
+}
+
+.help-button-container {
+    background-color: var(--secondary-ribbon-color);
+    border: none;
+    border-radius: 7.5px;
+    height: 100%;
+    width: 100%;
+}
+
+.help-button-container:hover {
+    background-color: white;
+}
+
+.help-button-container:hover > .help-button-circle {
+    background-color: var(--secondary-ribbon-color);
+}
+
+.help-button-container i {
+    color: var(--secondary-ribbon-color);
+}
+
+.help-button-container:hover i {
+    color: white;
+}
+
+.help-button {
+    background: transparent;
+    border: none;
+    border-radius: 7.5px;
+    display: flex;
+    height: 100%;
+    padding: calc(var(--ribbon-header-height) - 30px);
+    width: 100%;
+}
+
+.help-button > span {
+    margin: auto;
+}
+
+.help-button i:first-child {
+    font-size: 2.25em;
 }

--- a/packages/core/components/HeaderRibbon/HelpControl.tsx
+++ b/packages/core/components/HeaderRibbon/HelpControl.tsx
@@ -332,7 +332,6 @@ export default function HelpControl(props: Props) {
     return (
         <div className={props.className} id={props.id} onMouseLeave={() => setShowDropdown(false)}>
             <div className={styles.helpButtonContainer} ref={iconButtonReference}>
-                <div className={styles.helpButtonCircle} />
                 <IconButton
                     ariaDescription="Help menu"
                     iconProps={{ iconName: "Help" }}
@@ -340,6 +339,7 @@ export default function HelpControl(props: Props) {
                     onMouseEnter={() => !isCollapsed && setShowDropdown(true)}
                     styles={ICON_BUTTON_STYLES}
                 />
+                <div className={styles.helpButtonCircle} />
             </div>
             <ContextualMenu
                 items={helpOptions}

--- a/packages/core/components/HeaderRibbon/HelpControl.tsx
+++ b/packages/core/components/HeaderRibbon/HelpControl.tsx
@@ -1,0 +1,357 @@
+import {
+    ContextualMenu,
+    Icon,
+    IconButton,
+    IContextualMenuItem,
+    IContextualMenuItemProps,
+    IContextualMenuItemRenderFunctions,
+    IStyle,
+} from "@fluentui/react";
+import * as React from "react";
+import { useDispatch } from "react-redux";
+
+import Tutorial from "../../entity/Tutorial";
+import { interaction, selection } from "../../state";
+
+import styles from "./HeaderRibbon.module.css";
+
+interface Props {
+    className?: string;
+    id: string;
+    isCollapsed?: boolean;
+    onCollapse: () => void;
+}
+
+// Color is lightened tint of --primary-brand-dark-blue defined in App.module.css
+const LIGHTENED_PRIMARY_DARK_BLUE = "#1A4A71";
+// Equivalent to --primary-brand-dark-blue defined in App.module.css
+const PRIMARY_DARK_BLUE = "#003057";
+
+const MENU_STYLES: IStyle = {
+    backgroundColor: LIGHTENED_PRIMARY_DARK_BLUE,
+    color: "white",
+    ":hover": {
+        backgroundColor: PRIMARY_DARK_BLUE,
+        color: "white",
+    },
+    ":active": {
+        backgroundColor: PRIMARY_DARK_BLUE,
+        color: "white",
+    },
+};
+
+const OPTION_PROPS: Partial<IContextualMenuItemProps> = {
+    styles: {
+        label: {
+            color: "white",
+            textAlign: "right",
+        },
+        item: MENU_STYLES,
+        root: MENU_STYLES,
+    },
+};
+
+const ICON_BUTTON_STYLES = {
+    icon: {
+        color: "#FFFFFF",
+    },
+};
+
+const ORGANIZE_FILES_TUTORIAL = new Tutorial("Organizing")
+    .addStep({
+        targetId: Tutorial.ANNOTATION_LIST_ID,
+        message:
+            'All annotations that have files tagged with them are present in this list. Drag and drop an annotation in this list into the "Annotation Hierarchy" above (try "Cell Line" for example).',
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Each folder represents a value for the annotation and the files within the folder are guaranteed to have been annotated with that annotation name + value",
+    })
+    .addStep({
+        targetId: Tutorial.ANNOTATION_HIERARCHY_ID,
+        message:
+            "This will display the hierarchy of the dynamically generated folders to the right which are determined by the order in which you add annotations to this hierarchy (they can be rearranged by dragging them around)",
+    });
+
+const OPEN_FILES_TUTORIAL = new Tutorial("Opening files")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select the file you want to open (or at least one you could open like maybe a CZI)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead, this will open the file in the default application your computer has saved for this file type or just the last application used to open the same type',
+    });
+
+const GENERATE_MANIFEST_TUTORIAL = new Tutorial("Generating manifests")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click any of the highlighted files and select "Generate CSV manifest". This will open a modal in which you will be guided through creating a CSV that is a list of the files selected where the columns are the annotations present for those files.',
+    });
+
+const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click any of the highlighted files and select "Share Collection" then choose a Configuration. Use the default for this tutorial which will make the collection available for one day and allow the metadata to be updated (if any updates occur), but in the future select "Configure..." and explore the options available.',
+    })
+    .addStep({
+        targetId: Tutorial.COLLECTIONS_TITLE_ID,
+        message: (
+            <span>
+                Once the app reports that your collection has been created (as a status near the top
+                of the app) it will be available here in this dropdown. Select the option that has
+                your username + a timestamp of when you created it. If you used the default
+                configuration it will be present here for one day and only available to you{" "}
+                <strong>unless</strong> you share it using the URL feature (see the &quot;Sharing
+                current view&quot; tutorial for that)
+            </span>
+        ),
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'The files available to search against are now limited to just those selected to be a part of your collection. To return back to the default of "All of FMS" (i.e. all files) navigate to the Collection header again and select that option from the dropdown',
+    });
+
+const SHARE_VIEW_TUTORIAL = new Tutorial("Sharing current view (URL)")
+    .addStep({
+        targetId: Tutorial.COPY_URL_BUTTON_ID,
+        message:
+            "Copy your current view (i.e. your combination of filters, sorts, and open files) by clicking here. This will automatically copy the URL to your clipboard (like when you press Ctrl+C)",
+    })
+    .addStep({
+        targetId: Tutorial.URL_BOX_ID,
+        message: "Paste a copied view (URL) here and press Enter to have it load",
+    });
+
+const FILTER_FILES_TUTORIAL = new Tutorial("Filtering")
+    .addStep({
+        targetId: Tutorial.ANNOTATION_LIST_ID,
+        message: (
+            <span>
+                Filters for <strong>annotations</strong> can be found and used by clicking the{" "}
+                <Icon iconName="FilterSolid" /> icon for the annotation to filter by and selecting
+                which annotation values the files must have
+            </span>
+        ),
+    })
+    .addStep({
+        targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
+        message:
+            "Files can also be filtered by these attributes by selecting one from the dropdown menu (ex. 'Uploaded') " +
+            'and entering a value. The value for attributes like "File "name" do not have to be exact and can instead be ' +
+            'partial matches (ex. entering "AD0000057" would show file "AD00000573_100x_20220729_H01_001_Scene-44_aligned.ome.tiff")',
+    })
+    .addStep({
+        targetId: Tutorial.VIEWS_TITLE_ID,
+        message:
+            'Views can be useful to quickly apply a set of filters and sorts. Currently there are only "Views" surrounding the "Uploaded" attribute, but there could be more in the future.',
+    });
+
+const SORT_FILES_TUTORIAL = new Tutorial("Sorting").addStep({
+    targetId: Tutorial.COLUMN_HEADERS_ID,
+    message:
+        'Files can be sorted by clicking the title of a column, by default files are sorted by the "Uploaded" date. Can\'t find the column you want to sort by? To modify the columns shown so that you can sort by another column see the "Modifying columns in file list" tutorial.',
+});
+
+const MODIFY_COLUMNS_TUTORIAL = new Tutorial("Modifying file list columns").addStep({
+    targetId: Tutorial.COLUMN_HEADERS_ID,
+    message:
+        'The columns in the file list can be added or removed at will by right-clicking anywhere near the titles of the columns and selecting "Modify columns" and selecting which columns to show. The width of a column can be changed by dragging the bars | following the column titles.',
+});
+
+/**
+ * Menu group providing quick links to useful related pages and also a tutorial system
+ */
+export default function HelpControl(props: Props) {
+    const { isCollapsed } = props;
+    const dispatch = useDispatch();
+    const iconButtonReference = React.useRef(null);
+    const [showDropdown, setShowDropdown] = React.useState(false);
+
+    // Hide dropdown whenever whole component is collapsed
+    React.useEffect(() => {
+        if (isCollapsed) {
+            setShowDropdown(false);
+        }
+    }, [isCollapsed, setShowDropdown]);
+
+    type NewType = IContextualMenuItemProps;
+
+    const helpOptions: IContextualMenuItem[] = [
+        {
+            key: "submit-request",
+            text: "Submit Request",
+            title:
+                "Opens up a webpage where you can submit a JIRA ticket describing your request/feedback, we will contact you shortly after the ticket is made",
+            href:
+                "https://aicsjira.corp.alleninstitute.org/secure/project/CreateIssue.jspa?issuetype=1&pid=10406",
+            target: "_blank",
+            itemProps: OPTION_PROPS,
+        },
+        {
+            key: "download-newest-version",
+            text: "Download Newest Version",
+            title: "Opens the FMS File Explorer download page",
+            href: "https://alleninstitute.github.io/aics-fms-file-explorer-app/",
+            target: "_blank",
+            itemProps: OPTION_PROPS,
+        },
+        {
+            key: "tips-and-tricks",
+            text: "Tips & Tricks",
+            title:
+                "Opens a short description of some tips & tricks to hopefully improve your app experience",
+            onClick: () => {
+                props.onCollapse();
+                dispatch(interaction.actions.showTipsAndTricksDialog());
+            },
+            itemProps: OPTION_PROPS,
+        },
+        {
+            key: "tutorials",
+            text: "Tutorials",
+            title:
+                "List of available tutorials useful for getting familiar with the features of this application",
+            itemProps: OPTION_PROPS,
+            onRenderContent: (
+                props: NewType,
+                defaultRenders: IContextualMenuItemRenderFunctions
+            ) => (
+                <>
+                    <Icon iconName="CaretSolidLeft" />
+                    {defaultRenders.renderItemName(props)}
+                </>
+            ),
+            subMenuProps: {
+                items: [
+                    {
+                        key: "Organizing",
+                        text: 'Organizing ("Annotation Hierarchy")',
+                        title:
+                            "How to organize the files in the file list into hierarchical folders using the annotation hierarchy",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(ORGANIZE_FILES_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Filtering",
+                        text: "Filtering",
+                        title: "How to filter files in the file list",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(FILTER_FILES_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Sorting",
+                        text: "Sorting",
+                        title: "How to sort the files shown in the file list",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(SORT_FILES_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Modifying columns in file list",
+                        text: "Modifying columns in file list",
+                        title: "How to modify the columns present in the file list",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(MODIFY_COLUMNS_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Opening files in another application",
+                        text: "Opening files in another application",
+                        title:
+                            "How to open a file in another application without downloading or copying and pasting the file path",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(OPEN_FILES_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: 'Creating "Collections"',
+                        text: 'Creating "Collections"',
+                        title:
+                            'How to create a "Collection" of files for preservation, ML, or sharing purposes',
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(CREATE_COLLECTION_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Generating CSV manifests",
+                        text: "Generating CSV Manifests",
+                        title: "How to create a CSV manifest of files' metadata",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(GENERATE_MANIFEST_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                    {
+                        key: "Sharing current view (URL)",
+                        text: "Sharing current view (URL)",
+                        title:
+                            "How to share your current view (i.e. your filters/sorts/open folders etc.)",
+                        onClick: () => {
+                            props.onCollapse();
+                            dispatch(selection.actions.selectTutorial(SHARE_VIEW_TUTORIAL));
+                        },
+                        itemProps: OPTION_PROPS,
+                    },
+                ],
+            },
+        },
+    ];
+
+    return (
+        <div className={props.className} id={props.id} onMouseLeave={() => setShowDropdown(false)}>
+            <div className={styles.helpButtonContainer} ref={iconButtonReference}>
+                <div className={styles.helpButtonCircle} />
+                <IconButton
+                    ariaDescription="Help menu"
+                    iconProps={{ iconName: "Help" }}
+                    className={styles.helpButton}
+                    onMouseEnter={() => !isCollapsed && setShowDropdown(true)}
+                    styles={ICON_BUTTON_STYLES}
+                />
+            </div>
+            <ContextualMenu
+                items={helpOptions}
+                hidden={!showDropdown}
+                target={iconButtonReference.current}
+                onDismiss={() => setShowDropdown(false)}
+                onItemClick={() => setShowDropdown(false)}
+                // Auto adjusts width minimum to input width
+                useTargetAsMinWidth
+                // Required to have width auto-adjust
+                shouldUpdateWhenHidden
+            />
+        </div>
+    );
+}

--- a/packages/core/components/HeaderRibbon/HelpControl.tsx
+++ b/packages/core/components/HeaderRibbon/HelpControl.tsx
@@ -10,8 +10,17 @@ import {
 import * as React from "react";
 import { useDispatch } from "react-redux";
 
-import Tutorial from "../../entity/Tutorial";
 import { interaction, selection } from "../../state";
+import {
+    CREATE_COLLECTION_TUTORIAL,
+    FILTER_FILES_TUTORIAL,
+    GENERATE_MANIFEST_TUTORIAL,
+    MODIFY_COLUMNS_TUTORIAL,
+    OPEN_FILES_TUTORIAL,
+    ORGANIZE_FILES_TUTORIAL,
+    SHARE_VIEW_TUTORIAL,
+    SORT_FILES_TUTORIAL,
+} from "./tutorials";
 
 import styles from "./HeaderRibbon.module.css";
 
@@ -56,124 +65,6 @@ const ICON_BUTTON_STYLES = {
         color: "#FFFFFF",
     },
 };
-
-const ORGANIZE_FILES_TUTORIAL = new Tutorial("Organizing")
-    .addStep({
-        targetId: Tutorial.ANNOTATION_LIST_ID,
-        message:
-            'All annotations that have files tagged with them are present in this list. Drag and drop an annotation in this list into the "Annotation Hierarchy" above (try "Cell Line" for example).',
-    })
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            "Each folder represents a value for the annotation and the files within the folder are guaranteed to have been annotated with that annotation name + value",
-    })
-    .addStep({
-        targetId: Tutorial.ANNOTATION_HIERARCHY_ID,
-        message:
-            "This will display the hierarchy of the dynamically generated folders to the right which are determined by the order in which you add annotations to this hierarchy (they can be rearranged by dragging them around)",
-    });
-
-const OPEN_FILES_TUTORIAL = new Tutorial("Opening files")
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            "Select the file you want to open (or at least one you could open like maybe a CZI)",
-    })
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead, this will open the file in the default application your computer has saved for this file type or just the last application used to open the same type',
-    });
-
-const GENERATE_MANIFEST_TUTORIAL = new Tutorial("Generating manifests")
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
-    })
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            'Right-click any of the highlighted files and select "Generate CSV manifest". This will open a modal in which you will be guided through creating a CSV that is a list of the files selected where the columns are the annotations present for those files.',
-    });
-
-const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
-    })
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            'Right-click any of the highlighted files and select "Share Collection" then choose a Configuration. Use the default for this tutorial which will make the collection available for one day and allow the metadata to be updated (if any updates occur), but in the future select "Configure..." and explore the options available.',
-    })
-    .addStep({
-        targetId: Tutorial.COLLECTIONS_TITLE_ID,
-        message: (
-            <span>
-                Once the app reports that your collection has been created (as a status near the top
-                of the app) it will be available here in this dropdown. Select the option that has
-                your username + a timestamp of when you created it. If you used the default
-                configuration it will be present here for one day and only available to you{" "}
-                <strong>unless</strong> you share it using the URL feature (see the &quot;Sharing
-                current view&quot; tutorial for that)
-            </span>
-        ),
-    })
-    .addStep({
-        targetId: Tutorial.FILE_LIST_ID,
-        message:
-            'The files available to search against are now limited to just those selected to be a part of your collection. To return back to the default of "All of FMS" (i.e. all files) navigate to the Collection header again and select that option from the dropdown',
-    });
-
-const SHARE_VIEW_TUTORIAL = new Tutorial("Sharing current view (URL)")
-    .addStep({
-        targetId: Tutorial.COPY_URL_BUTTON_ID,
-        message:
-            "Copy your current view (i.e. your combination of filters, sorts, and open files) by clicking here. This will automatically copy the URL to your clipboard (like when you press Ctrl+C)",
-    })
-    .addStep({
-        targetId: Tutorial.URL_BOX_ID,
-        message: "Paste a copied view (URL) here and press Enter to have it load",
-    });
-
-const FILTER_FILES_TUTORIAL = new Tutorial("Filtering")
-    .addStep({
-        targetId: Tutorial.ANNOTATION_LIST_ID,
-        message: (
-            <span>
-                Filters for <strong>annotations</strong> can be found and used by clicking the{" "}
-                <Icon iconName="FilterSolid" /> icon for the annotation to filter by and selecting
-                which annotation values the files must have
-            </span>
-        ),
-    })
-    .addStep({
-        targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
-        message:
-            "Files can also be filtered by these attributes by selecting one from the dropdown menu (ex. 'Uploaded') " +
-            'and entering a value. The value for attributes like "File "name" do not have to be exact and can instead be ' +
-            'partial matches (ex. entering "AD0000057" would show file "AD00000573_100x_20220729_H01_001_Scene-44_aligned.ome.tiff")',
-    })
-    .addStep({
-        targetId: Tutorial.VIEWS_TITLE_ID,
-        message:
-            'Views can be useful to quickly apply a set of filters and sorts. Currently there are only "Views" surrounding the "Uploaded" attribute, but there could be more in the future.',
-    });
-
-const SORT_FILES_TUTORIAL = new Tutorial("Sorting").addStep({
-    targetId: Tutorial.COLUMN_HEADERS_ID,
-    message:
-        'Files can be sorted by clicking the title of a column, by default files are sorted by the "Uploaded" date. Can\'t find the column you want to sort by? To modify the columns shown so that you can sort by another column see the "Modifying columns in file list" tutorial.',
-});
-
-const MODIFY_COLUMNS_TUTORIAL = new Tutorial("Modifying file list columns").addStep({
-    targetId: Tutorial.COLUMN_HEADERS_ID,
-    message:
-        'The columns in the file list can be added or removed at will by right-clicking anywhere near the titles of the columns and selecting "Modify columns" and selecting which columns to show. The width of a column can be changed by dragging the bars | following the column titles.',
-});
 
 /**
  * Menu group providing quick links to useful related pages and also a tutorial system

--- a/packages/core/components/HeaderRibbon/HelpControl.tsx
+++ b/packages/core/components/HeaderRibbon/HelpControl.tsx
@@ -132,8 +132,8 @@ export default function HelpControl(props: Props) {
             subMenuProps: {
                 items: [
                     {
-                        key: "Organizing",
-                        text: 'Organizing ("Annotation Hierarchy")',
+                        key: "Annotation Hierarchy",
+                        text: "Annotation Hierarchy",
                         title:
                             "How to organize the files in the file list into hierarchical folders using the annotation hierarchy",
                         onClick: () => {

--- a/packages/core/components/HeaderRibbon/ViewControl.tsx
+++ b/packages/core/components/HeaderRibbon/ViewControl.tsx
@@ -11,7 +11,6 @@ import styles from "./HeaderRibbon.module.css";
 interface Props {
     className?: string;
     isCollapsed?: boolean;
-    onCollapse: () => void;
 }
 
 const MENU_STYLES: IStyle = {

--- a/packages/core/components/HeaderRibbon/index.tsx
+++ b/packages/core/components/HeaderRibbon/index.tsx
@@ -20,7 +20,7 @@ const COLLECTION_TOOLTIP =
 const VIEW_TOOLTIP =
     'A "view" is a pre-selected set of filters and/or sorts that when selected using this dropdown will add to (or potentially replace) your current filters and/or sorts with the pre-selected filters/sorts. You can then add or remove any filters/sorts at will.';
 const HELP_TOOLTIP =
-    "This menu provides access to tutorials and useful links to things like the new version download page";
+    "This menu provides quick links to related pages, as well as a tutorial system";
 
 const HELP_CONTROL_ID = "help-control";
 const HELP_TITLE_ID = "help-title";
@@ -110,8 +110,8 @@ export default function HeaderRibbon(props: HeaderRibbonProps) {
                         },
                     }}
                 >
-                    New or returning user? Please check this Help section for useful links and
-                    tutorials, the tutorial list might help uncover features you might not know
+                    New or returning user? Please refer to this Help section for useful links and
+                    tutorials. The tutorial list might help uncover features you might not know
                     about!
                 </TeachingBubble>
             )}

--- a/packages/core/components/HeaderRibbon/index.tsx
+++ b/packages/core/components/HeaderRibbon/index.tsx
@@ -20,7 +20,7 @@ const COLLECTION_TOOLTIP =
 const VIEW_TOOLTIP =
     'A "view" is a pre-selected set of filters and/or sorts that when selected using this dropdown will add to (or potentially replace) your current filters and/or sorts with the pre-selected filters/sorts. You can then add or remove any filters/sorts at will.';
 const HELP_TOOLTIP =
-    "This menu provides quick links to related pages, as well as a tutorial system";
+    "This menu provides quick links to related pages, as well as a tutorial system.";
 
 const HELP_CONTROL_ID = "help-control";
 const HELP_TITLE_ID = "help-title";

--- a/packages/core/components/HeaderRibbon/index.tsx
+++ b/packages/core/components/HeaderRibbon/index.tsx
@@ -1,13 +1,15 @@
+import { Icon, TeachingBubble, TooltipHost } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
-import { selection } from "../../state";
+import Tutorial from "../../entity/Tutorial";
+import { interaction, selection } from "../../state";
 import CollectionControl from "./CollectionControl";
+import HelpControl from "./HelpControl";
 import ViewControl from "./ViewControl";
 
 import styles from "./HeaderRibbon.module.css";
-import { Icon, TooltipHost } from "@fluentui/react";
 
 interface HeaderRibbonProps {
     className?: string;
@@ -17,31 +19,52 @@ const COLLECTION_TOOLTIP =
     'A "collection" is a previously saved set of files. Selecting one of these will narrow down the possible set of findable files down to those saved within this collection. You can create collections by selecting files, right-clicking, and selecting "Share Collection."';
 const VIEW_TOOLTIP =
     'A "view" is a pre-selected set of filters and/or sorts that when selected using this dropdown will add to (or potentially replace) your current filters and/or sorts with the pre-selected filters/sorts. You can then add or remove any filters/sorts at will.';
+const HELP_TOOLTIP =
+    "This menu provides access to tutorials and useful links to things like the new version download page";
+
+const HELP_CONTROL_ID = "help-control";
+const HELP_TITLE_ID = "help-title";
 
 /**
  * Ribbon-like toolbar at the top of the application to contain features like application-level view options.
  */
 export default function HeaderRibbon(props: HeaderRibbonProps) {
+    const dispatch = useDispatch();
     const selectedCollection = useSelector(selection.selectors.getCollection);
+    const hasUsedApplicationBefore = useSelector(interaction.selectors.hasUsedApplicationBefore);
 
     const [isCollapsed, setCollapsed] = React.useState(true);
+
+    function onMouseLeaveHeaderRibbon() {
+        setCollapsed(true);
+        dispatch(interaction.actions.markAsUsedApplicationBefore());
+    }
 
     return (
         <div
             className={classNames(styles.root, props.className)}
             onMouseEnter={() => setCollapsed(false)}
-            onMouseLeave={() => setCollapsed(true)}
+            onMouseLeave={onMouseLeaveHeaderRibbon}
         >
             <div className={styles.headerBar}>
                 <h5 className={styles.controlGroup}>
-                    <div>Collection {selectedCollection && `(${selectedCollection?.name})`}</div>
+                    <div id={Tutorial.COLLECTIONS_TITLE_ID}>
+                        Collection {selectedCollection && `(${selectedCollection?.name})`}
+                    </div>
                     <TooltipHost content={COLLECTION_TOOLTIP}>
                         <Icon className={styles.infoIcon} iconName="Info" />
                     </TooltipHost>
                 </h5>
                 <h5 className={styles.controlGroup}>
-                    <div>View</div>
+                    <div id={Tutorial.VIEWS_TITLE_ID}>View</div>
                     <TooltipHost content={VIEW_TOOLTIP}>
+                        <Icon className={styles.infoIcon} iconName="Info" />
+                    </TooltipHost>
+                </h5>
+                <div className={classNames(styles.controlGroup, styles.filler)} />
+                <h5 className={classNames(styles.controlGroup, styles.smallerControlGroup)}>
+                    <div id={HELP_TITLE_ID}>Help</div>
+                    <TooltipHost content={HELP_TOOLTIP}>
                         <Icon className={styles.infoIcon} iconName="Info" />
                     </TooltipHost>
                 </h5>
@@ -53,12 +76,45 @@ export default function HeaderRibbon(props: HeaderRibbonProps) {
                     selectedCollection={selectedCollection}
                     onCollapse={() => setCollapsed(true)}
                 />
-                <ViewControl
-                    className={styles.controlGroup}
+                <ViewControl className={styles.controlGroup} isCollapsed={isCollapsed} />
+                <div className={classNames(styles.controlGroup, styles.filler)} />
+                <HelpControl
+                    className={classNames(styles.controlGroup, styles.smallerControlGroup)}
+                    id={HELP_CONTROL_ID}
                     isCollapsed={isCollapsed}
                     onCollapse={() => setCollapsed(true)}
                 />
             </div>
+            {!hasUsedApplicationBefore && (
+                <TeachingBubble
+                    hasCloseButton
+                    hasSmallHeadline
+                    onDismiss={() => dispatch(interaction.actions.markAsUsedApplicationBefore())}
+                    headline="Check this out first!"
+                    target={`#${isCollapsed ? HELP_TITLE_ID : HELP_CONTROL_ID}`}
+                    styles={{
+                        closeButton: {
+                            ":hover": {
+                                backgroundColor: "#FFFFFF",
+                                // Equivalent to --primary-brand-purple defined in App.module.css
+                                color: "#827aa3",
+                            },
+                        },
+                        root: {
+                            className: styles.tutorialContainer,
+                            " div": {
+                                // Equivalent to --primary-brand-purple defined in App.module.css
+                                backgroundColor: "#827aa3",
+                                color: "white",
+                            },
+                        },
+                    }}
+                >
+                    New or returning user? Please check this Help section for useful links and
+                    tutorials, the tutorial list might help uncover features you might not know
+                    about!
+                </TeachingBubble>
+            )}
         </div>
     );
 }

--- a/packages/core/components/HeaderRibbon/test/ViewControl.test.tsx
+++ b/packages/core/components/HeaderRibbon/test/ViewControl.test.tsx
@@ -1,7 +1,6 @@
 import { configureMockStore } from "@aics/redux-utils";
 import { fireEvent, render } from "@testing-library/react";
 import { expect } from "chai";
-import { noop } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
 import { RELATIVE_DATE_RANGES } from "../../../constants";
@@ -17,7 +16,7 @@ describe("<ViewControl />", () => {
         });
         const { getByPlaceholderText } = render(
             <Provider store={store}>
-                <ViewControl onCollapse={noop} />
+                <ViewControl />
             </Provider>
         );
 
@@ -33,7 +32,7 @@ describe("<ViewControl />", () => {
         });
         const { getByText, getByPlaceholderText } = render(
             <Provider store={store}>
-                <ViewControl onCollapse={noop} />
+                <ViewControl />
             </Provider>
         );
 

--- a/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import Tutorial from "../../../entity/Tutorial";
+
+export const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click any of the highlighted files and select "Share Collection" then choose a Configuration. Use the default for this tutorial which will make the collection available for one day and allow the metadata to be updated (if any updates occur), but in the future select "Configure..." and explore the options available.',
+    })
+    .addStep({
+        targetId: Tutorial.COLLECTIONS_TITLE_ID,
+        message: (
+            <span>
+                Once the app reports that your collection has been created (as a status near the top
+                of the app) it will be available here in this dropdown. Select the option that has
+                your username + a timestamp of when you created it. If you used the default
+                configuration it will be present here for one day and only available to you{" "}
+                <strong>unless</strong> you share it using the URL feature (see the &quot;Sharing
+                current view&quot; tutorial for that)
+            </span>
+        ),
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'The files available to search against are now limited to just those selected to be a part of your collection. To return back to the default of "All of FMS" (i.e. all files) navigate to the Collection header again and select that option from the dropdown',
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
@@ -6,12 +6,12 @@ export const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+            'Select a file by left-clicking it. You may also select multiple files by holding "Shift" or "Ctrl"',
     })
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'Right-click any of the highlighted files and select "Share Collection" then choose a Configuration. Use the default for this tutorial which will make the collection available for one day and allow the metadata to be updated (if any updates occur), but in the future select "Configure..." and explore the options available.',
+            'Right-click any of the highlighted files and select "Share Collection". Then, choose a Configuration. For this tutorial, use the default. This will make the collection available for one day and allow the metadata to be updated (if any updates occur). In the future, select "Configure..." and explore the options available.',
     })
     .addStep({
         targetId: Tutorial.COLLECTIONS_TITLE_ID,
@@ -20,7 +20,7 @@ export const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
                 Once the app reports that your collection has been created (as a status near the top
                 of the app) it will be available here in this dropdown. Select the option that has
                 your username + a timestamp of when you created it. If you used the default
-                configuration it will be present here for one day and only available to you{" "}
+                configuration it will be present here for one day and only available to you,{" "}
                 <strong>unless</strong> you share it using the URL feature (see the &quot;Sharing
                 current view&quot; tutorial for that)
             </span>

--- a/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/CreateCollection.tsx
@@ -6,7 +6,7 @@ export const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'Select a file by left-clicking it. You may also select multiple files by holding "Shift" or "Ctrl"',
+            'Select a file by left-clicking it. You may also select multiple files by holding "Shift" or "Ctrl."',
     })
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
@@ -29,5 +29,5 @@ export const CREATE_COLLECTION_TUTORIAL = new Tutorial("Creating collections")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'The files available to search against are now limited to just those selected to be a part of your collection. To return back to the default of "All of FMS" (i.e. all files) navigate to the Collection header again and select that option from the dropdown',
+            'The files available to search against are now limited to just those selected to be a part of your collection. To return back to the default of "All of FMS" (i.e. all files) navigate to the Collection header again and select that option from the dropdown.',
     });

--- a/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
@@ -1,0 +1,28 @@
+import { Icon } from "@fluentui/react";
+import * as React from "react";
+
+import Tutorial from "../../../entity/Tutorial";
+
+export const FILTER_FILES_TUTORIAL = new Tutorial("Filtering")
+    .addStep({
+        targetId: Tutorial.ANNOTATION_LIST_ID,
+        message: (
+            <span>
+                Filters for <strong>annotations</strong> can be found and used by clicking the{" "}
+                <Icon iconName="FilterSolid" /> icon for the annotation to filter by and selecting
+                which annotation values the files must have
+            </span>
+        ),
+    })
+    .addStep({
+        targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
+        message:
+            "Files can also be filtered by these attributes by selecting one from the dropdown menu (ex. 'Uploaded') " +
+            'and entering a value. The value for attributes like "File "name" do not have to be exact and can instead be ' +
+            'partial matches (ex. entering "AD0000057" would show file "AD00000573_100x_20220729_H01_001_Scene-44_aligned.ome.tiff")',
+    })
+    .addStep({
+        targetId: Tutorial.VIEWS_TITLE_ID,
+        message:
+            'Views can be useful to quickly apply a set of filters and sorts. Currently there are only "Views" surrounding the "Uploaded" attribute, but there could be more in the future.',
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
@@ -15,7 +15,7 @@ export const FILTER_FILES_TUTORIAL = new Tutorial("Filtering")
     })
     .addStep({
         targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
-        message: "All files have the attributes listed in this dropdown",
+        message: "All files have the attributes listed in this dropdown.",
     })
     .addStep({
         targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,

--- a/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
+++ b/packages/core/components/HeaderRibbon/tutorials/FilterFiles.tsx
@@ -8,18 +8,19 @@ export const FILTER_FILES_TUTORIAL = new Tutorial("Filtering")
         targetId: Tutorial.ANNOTATION_LIST_ID,
         message: (
             <span>
-                Filters for <strong>annotations</strong> can be found and used by clicking the{" "}
-                <Icon iconName="FilterSolid" /> icon for the annotation to filter by and selecting
-                which annotation values the files must have
+                Filter for specific annotation values by clicking the{" "}
+                <Icon iconName="FilterSolid" /> icon next to the annotation you want to filter by.
             </span>
         ),
     })
     .addStep({
         targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
+        message: "All files have the attributes listed in this dropdown",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_ATTRIBUTE_FILTER_ID,
         message:
-            "Files can also be filtered by these attributes by selecting one from the dropdown menu (ex. 'Uploaded') " +
-            'and entering a value. The value for attributes like "File "name" do not have to be exact and can instead be ' +
-            'partial matches (ex. entering "AD0000057" would show file "AD00000573_100x_20220729_H01_001_Scene-44_aligned.ome.tiff")',
+            'You can filter on the selected attribute by entering a value here. These values do not have to be exact, e.g. entering a File Name of "ZSD1" would return all files with names starting with or containing "ZSD1".',
     })
     .addStep({
         targetId: Tutorial.VIEWS_TITLE_ID,

--- a/packages/core/components/HeaderRibbon/tutorials/GenerateManifest.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/GenerateManifest.ts
@@ -1,0 +1,13 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const GENERATE_MANIFEST_TUTORIAL = new Tutorial("Generating manifests")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click any of the highlighted files and select "Generate CSV manifest". This will open a modal in which you will be guided through creating a CSV that is a list of the files selected where the columns are the annotations present for those files.',
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/GenerateManifest.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/GenerateManifest.ts
@@ -4,10 +4,10 @@ export const GENERATE_MANIFEST_TUTORIAL = new Tutorial("Generating manifests")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            "Select a file by left-clicking or multiple by holding Shift or Ctrl and clicking multiple files (any will do for this tutorial)",
+            "You can generate CSV manifests containing a list of FMS files' metadata. Start by selecting any number of files from the file list.",
     })
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'Right-click any of the highlighted files and select "Generate CSV manifest". This will open a modal in which you will be guided through creating a CSV that is a list of the files selected where the columns are the annotations present for those files.',
+            'Right-click any of the highlighted files and select "Generate CSV manifest". This will open a modal in which you will be guided through creating a CSV that contains a list of the selected files where the columns are the annotations present for those files.',
     });

--- a/packages/core/components/HeaderRibbon/tutorials/ModifyColumns.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/ModifyColumns.ts
@@ -3,5 +3,5 @@ import Tutorial from "../../../entity/Tutorial";
 export const MODIFY_COLUMNS_TUTORIAL = new Tutorial("Modifying file list columns").addStep({
     targetId: Tutorial.COLUMN_HEADERS_ID,
     message:
-        'The columns in the file list can be added or removed at will by right-clicking anywhere near the titles of the columns and selecting "Modify columns" and selecting which columns to show. The width of a column can be changed by dragging the bars | following the column titles.',
+        'The columns in the file list can be added or removed at will by right-clicking anywhere near the titles of the columns, selecting "Modify columns", and then selecting which columns to show. The width of a column can be changed by dragging the bars | following the column titles.',
 });

--- a/packages/core/components/HeaderRibbon/tutorials/ModifyColumns.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/ModifyColumns.ts
@@ -1,0 +1,7 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const MODIFY_COLUMNS_TUTORIAL = new Tutorial("Modifying file list columns").addStep({
+    targetId: Tutorial.COLUMN_HEADERS_ID,
+    message:
+        'The columns in the file list can be added or removed at will by right-clicking anywhere near the titles of the columns and selecting "Modify columns" and selecting which columns to show. The width of a column can be changed by dragging the bars | following the column titles.',
+});

--- a/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
@@ -1,0 +1,13 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const OPEN_FILES_TUTORIAL = new Tutorial("Opening files")
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Select the file you want to open (or at least one you could open like maybe a CZI)",
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead, this will open the file in the default application your computer has saved for this file type or just the last application used to open the same type',
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
@@ -4,10 +4,10 @@ export const OPEN_FILES_TUTORIAL = new Tutorial("Opening files")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            "Select the file you want to open (or at least one you could open like maybe a CZI)",
+            "You can open files from the file list using other applications. Start by selecting the file you want to open.",
     })
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead, this will open the file in the default application your computer has saved for this file type or just the last application used to open the same type',
+            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead. This will open the file in the default application your computer has saved for this file type, or just the last application used to open the same type',
     });

--- a/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OpenFiles.ts
@@ -9,5 +9,5 @@ export const OPEN_FILES_TUTORIAL = new Tutorial("Opening files")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead. This will open the file in the default application your computer has saved for this file type, or just the last application used to open the same type',
+            'Right-click the now highlighted file and select "Open with" to select a specific application with which to open the file in. You can also have the explorer guess at which application to open by selecting the "Open" option instead. This will open the file in the default application your computer has saved for this file type, or just the last application used to open the same type.',
     });

--- a/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
@@ -1,0 +1,18 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const ORGANIZE_FILES_TUTORIAL = new Tutorial("Organizing")
+    .addStep({
+        targetId: Tutorial.ANNOTATION_LIST_ID,
+        message:
+            'All annotations that have files tagged with them are present in this list. Drag and drop an annotation in this list into the "Annotation Hierarchy" above (try "Cell Line" for example).',
+    })
+    .addStep({
+        targetId: Tutorial.FILE_LIST_ID,
+        message:
+            "Each folder represents a value for the annotation and the files within the folder are guaranteed to have been annotated with that annotation name + value",
+    })
+    .addStep({
+        targetId: Tutorial.ANNOTATION_HIERARCHY_ID,
+        message:
+            "This will display the hierarchy of the dynamically generated folders to the right which are determined by the order in which you add annotations to this hierarchy (they can be rearranged by dragging them around)",
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
@@ -9,10 +9,10 @@ export const ORGANIZE_FILES_TUTORIAL = new Tutorial("Organizing")
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            "Each folder represents a value for the annotation. The files within the folder are guaranteed to have been annotated with that annotation name + value",
+            "Each folder represents a value for the annotation. The files within the folder are guaranteed to have been annotated with that annotation name + value.",
     })
     .addStep({
         targetId: Tutorial.ANNOTATION_HIERARCHY_ID,
         message:
-            "This will display the hierarchy of the dynamically generated folders to the right which are determined by the order in which you add annotations to this hierarchy (they can be rearranged by dragging them around)",
+            "This will display the hierarchy of the dynamically generated folders to the right which are determined by the order in which you add annotations to this hierarchy (they can be rearranged by dragging them around).",
     });

--- a/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/OrganizeFiles.ts
@@ -4,12 +4,12 @@ export const ORGANIZE_FILES_TUTORIAL = new Tutorial("Organizing")
     .addStep({
         targetId: Tutorial.ANNOTATION_LIST_ID,
         message:
-            'All annotations that have files tagged with them are present in this list. Drag and drop an annotation in this list into the "Annotation Hierarchy" above (try "Cell Line" for example).',
+            'All annotations that have files tagged with them are present in this list. Drag and drop an annotation (e.g. "Cell Line") from this list into the "Annotation Hierarchy" above.',
     })
     .addStep({
         targetId: Tutorial.FILE_LIST_ID,
         message:
-            "Each folder represents a value for the annotation and the files within the folder are guaranteed to have been annotated with that annotation name + value",
+            "Each folder represents a value for the annotation. The files within the folder are guaranteed to have been annotated with that annotation name + value",
     })
     .addStep({
         targetId: Tutorial.ANNOTATION_HIERARCHY_ID,

--- a/packages/core/components/HeaderRibbon/tutorials/ShareView.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/ShareView.ts
@@ -4,9 +4,9 @@ export const SHARE_VIEW_TUTORIAL = new Tutorial("Sharing current view (URL)")
     .addStep({
         targetId: Tutorial.COPY_URL_BUTTON_ID,
         message:
-            "Copy your current view (i.e. your combination of filters, sorts, and open files) by clicking here. This will automatically copy the URL to your clipboard (like when you press Ctrl+C)",
+            "Copy your current view (i.e. your combination of filters, sorts, and open files) by clicking here. This will automatically copy the URL to your clipboard (like when you press Ctrl+C).",
     })
     .addStep({
         targetId: Tutorial.URL_BOX_ID,
-        message: "Paste a copied view (URL) here and press Enter to have it load",
+        message: "Paste a copied view (URL) here and press Enter to have it load.",
     });

--- a/packages/core/components/HeaderRibbon/tutorials/ShareView.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/ShareView.ts
@@ -1,0 +1,12 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const SHARE_VIEW_TUTORIAL = new Tutorial("Sharing current view (URL)")
+    .addStep({
+        targetId: Tutorial.COPY_URL_BUTTON_ID,
+        message:
+            "Copy your current view (i.e. your combination of filters, sorts, and open files) by clicking here. This will automatically copy the URL to your clipboard (like when you press Ctrl+C)",
+    })
+    .addStep({
+        targetId: Tutorial.URL_BOX_ID,
+        message: "Paste a copied view (URL) here and press Enter to have it load",
+    });

--- a/packages/core/components/HeaderRibbon/tutorials/SortFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/SortFiles.ts
@@ -1,0 +1,7 @@
+import Tutorial from "../../../entity/Tutorial";
+
+export const SORT_FILES_TUTORIAL = new Tutorial("Sorting").addStep({
+    targetId: Tutorial.COLUMN_HEADERS_ID,
+    message:
+        'Files can be sorted by clicking the title of a column, by default files are sorted by the "Uploaded" date. Can\'t find the column you want to sort by? To modify the columns shown so that you can sort by another column see the "Modifying columns in file list" tutorial.',
+});

--- a/packages/core/components/HeaderRibbon/tutorials/SortFiles.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/SortFiles.ts
@@ -3,5 +3,5 @@ import Tutorial from "../../../entity/Tutorial";
 export const SORT_FILES_TUTORIAL = new Tutorial("Sorting").addStep({
     targetId: Tutorial.COLUMN_HEADERS_ID,
     message:
-        'Files can be sorted by clicking the title of a column, by default files are sorted by the "Uploaded" date. Can\'t find the column you want to sort by? To modify the columns shown so that you can sort by another column see the "Modifying columns in file list" tutorial.',
+        'Files can be sorted by clicking the title of a column. By default, files are sorted by the "Uploaded" date. Can\'t find the column you want to sort by? To modify the columns shown so that you can sort by another column, see the "Modifying columns in file list" tutorial.',
 });

--- a/packages/core/components/HeaderRibbon/tutorials/index.ts
+++ b/packages/core/components/HeaderRibbon/tutorials/index.ts
@@ -1,0 +1,19 @@
+import { CREATE_COLLECTION_TUTORIAL } from "./CreateCollection";
+import { FILTER_FILES_TUTORIAL } from "./FilterFiles";
+import { GENERATE_MANIFEST_TUTORIAL } from "./GenerateManifest";
+import { MODIFY_COLUMNS_TUTORIAL } from "./ModifyColumns";
+import { OPEN_FILES_TUTORIAL } from "./OpenFiles";
+import { ORGANIZE_FILES_TUTORIAL } from "./OrganizeFiles";
+import { SHARE_VIEW_TUTORIAL } from "./ShareView";
+import { SORT_FILES_TUTORIAL } from "./SortFiles";
+
+export {
+    CREATE_COLLECTION_TUTORIAL,
+    FILTER_FILES_TUTORIAL,
+    GENERATE_MANIFEST_TUTORIAL,
+    MODIFY_COLUMNS_TUTORIAL,
+    OPEN_FILES_TUTORIAL,
+    ORGANIZE_FILES_TUTORIAL,
+    SHARE_VIEW_TUTORIAL,
+    SORT_FILES_TUTORIAL,
+};

--- a/packages/core/components/Modal/TipsAndTricks/index.tsx
+++ b/packages/core/components/Modal/TipsAndTricks/index.tsx
@@ -11,26 +11,26 @@ export default function TipsAndTricks({ onDismiss }: ModalProps) {
         <>
             <h4>Performance</h4>
             <p>
-                Some searches can be slow. This tends to occur because of the amount of files which
-                can almost always be narrowed down. For example, 5 million files might have
-                annotation &quot;Kind&quot; with a value of &quot;CZI Image&quot;, instead of
-                searching by File name through all those files narrow them down with another
-                annotation or just by something simple like the date they were uploaded. Use the
+                Some searches can be slow. This tends to occur because they return a high number of
+                files, which can almost always be narrowed down. For example, 5 million files might
+                have annotation &quot;Kind&quot; with a value of &quot;CZI Image&quot;. Instead of
+                searching by File name through all those files, narrow them down with another
+                annotation, or by something simple like the date they were uploaded. Use the
                 &quot;View&quot; feature at the top of the app to automatically narrow files down by
                 the date they were uploaded relative to todays date.
             </p>
             <h4>How to</h4>
             <p>
                 Unsure how a feature works? Check out the &quot;Tutorials&quot; section of the help
-                menu, a feature might have some hidden aspects you are not aware of or there might
+                menu. A feature might have some hidden aspects you are not aware of, or there might
                 even be features there you did not know about.
             </p>
             <h4>Getting help</h4>
             <p>
-                The software team is, at the time of writing this, using Slack as the means of
-                reaching us for help with our apps. Post whatever your question may be in our
-                support channel and you should receive help quickly, nothing it too niche to ask
-                about.
+                At the time of writing, the primary means of contacting the Software team for help
+                is through our #support_aics_software Slack channel. Post whatever your question may
+                be in the support channel and you should receive help quickly. Nothing is too niche
+                to ask about.
             </p>
         </>
     );

--- a/packages/core/components/Modal/TipsAndTricks/index.tsx
+++ b/packages/core/components/Modal/TipsAndTricks/index.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import BaseModal from "../BaseModal";
+import { ModalProps } from "..";
+
+/**
+ * Dialog meant to explain some tips and tricks
+ */
+export default function TipsAndTricks({ onDismiss }: ModalProps) {
+    const body = (
+        <>
+            <h4>Performance</h4>
+            <p>
+                Some searches can be slow. This tends to occur because of the amount of files which
+                can almost always be narrowed down. For example, 5 million files might have
+                annotation &quot;Kind&quot; with a value of &quot;CZI Image&quot;, instead of
+                searching by File name through all those files narrow them down with another
+                annotation or just by something simple like the date they were uploaded. Use the
+                &quot;View&quot; feature at the top of the app to automatically narrow files down by
+                the date they were uploaded relative to todays date.
+            </p>
+            <h4>How to</h4>
+            <p>
+                Unsure how a feature works? Check out the &quot;Tutorials&quot; section of the help
+                menu, a feature might have some hidden aspects you are not aware of or there might
+                even be features there you did not know about.
+            </p>
+            <h4>Getting help</h4>
+            <p>
+                The software team is, at the time of writing this, using Slack as the means of
+                reaching us for help with our apps. Post whatever your question may be in our
+                support channel and you should receive help quickly, nothing it too niche to ask
+                about.
+            </p>
+        </>
+    );
+
+    return <BaseModal body={body} onDismiss={onDismiss} title="Tips & Tricks" />;
+}

--- a/packages/core/components/Modal/TipsAndTricks/test/TipsAndTricks.test.tsx
+++ b/packages/core/components/Modal/TipsAndTricks/test/TipsAndTricks.test.tsx
@@ -1,0 +1,29 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+
+import Modal, { ModalType } from "../..";
+import { initialState } from "../../../../state";
+
+describe("<TipsAndTricks />", () => {
+    const visibleDialogState = mergeState(initialState, {
+        interaction: {
+            visibleModal: ModalType.TipsAndTricks,
+        },
+    });
+
+    it("is visible when should not be hidden", () => {
+        // Arrange
+        const { store } = configureMockStore({ state: visibleDialogState });
+        const { getByText } = render(
+            <Provider store={store}>
+                <Modal />
+            </Provider>
+        );
+
+        // Assert
+        expect(getByText("Performance")).to.exist;
+    });
+});

--- a/packages/core/components/Modal/index.tsx
+++ b/packages/core/components/Modal/index.tsx
@@ -5,6 +5,7 @@ import { interaction } from "../../state";
 import CsvManifest from "./CsvManifest";
 import CollectionForm from "./CollectionForm";
 import PythonSnippet from "./PythonSnippet";
+import TipsAndTricks from "./TipsAndTricks";
 
 export interface ModalProps {
     onDismiss: () => void;
@@ -15,6 +16,7 @@ export enum ModalType {
     CsvManifest = 2,
     EditCollectionForm = 3,
     PythonSnippet = 4,
+    TipsAndTricks = 5,
 }
 
 /**
@@ -37,6 +39,8 @@ export default function Modal() {
             return <CollectionForm isEditing onDismiss={onDismiss} />;
         case ModalType.PythonSnippet:
             return <PythonSnippet onDismiss={onDismiss} />;
+        case ModalType.TipsAndTricks:
+            return <TipsAndTricks onDismiss={onDismiss} />;
         default:
             return null;
     }

--- a/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
+++ b/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
@@ -1,0 +1,50 @@
+.button-footer {
+    display: flex;
+}
+
+.header {
+    display: flex;
+}
+
+.header > h6 {
+    margin-left: auto;
+}
+
+.tutorial-container {
+    background-color: var(--primary-brand-purple);
+}
+
+.tutorial-step-button {
+    border: none;
+    background-color: var(--secondary-brand-purple);
+}
+
+.tutorial-step-button.disabled:hover {
+    border: none;
+    background: none;
+}
+
+.tutorial-step-button:hover {
+    background-color: white;
+}
+
+.tutorial-step-button:first-child {
+    margin-left: auto;
+}
+
+.tutorial-step-button:last-child i {
+    font-size: 1.5em;
+    font-weight: bolder;
+}
+
+.tutorial-step-button i {
+    color: white;
+}
+
+.tutorial-step-button:hover i {
+    color: var(--primary-brand-purple);
+}
+
+.tutorial-step-button.disabled i {
+    opacity: 0;
+}

--- a/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
+++ b/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
@@ -1,3 +1,8 @@
+.bigger-icon {
+    font-size: 1.5em;
+    font-weight: bolder;
+}
+
 .button-footer {
     display: flex;
 }
@@ -30,11 +35,6 @@
 
 .tutorial-step-button:first-child {
     margin-left: auto;
-}
-
-.tutorial-step-button:last-child i {
-    font-size: 1.5em;
-    font-weight: bolder;
 }
 
 .tutorial-step-button i {

--- a/packages/core/components/TutorialTooltip/index.tsx
+++ b/packages/core/components/TutorialTooltip/index.tsx
@@ -1,0 +1,78 @@
+import { IconButton, TeachingBubble } from "@fluentui/react";
+import classNames from "classnames";
+import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { selection } from "../../state";
+
+import styles from "./TutorialTooltip.module.css";
+
+/**
+ * Component responsible for responding to and displaying the current tutorial
+ * selected in the redux state.
+ */
+export default function TutorialTooltip() {
+    const dispatch = useDispatch();
+    const tutorial = useSelector(selection.selectors.getTutorial);
+    const [tutorialStepIndex, setTutorialStepIndex] = React.useState(0);
+    if (!tutorial) {
+        return null;
+    }
+
+    const nextStepIndex = tutorialStepIndex + 1;
+    const previousStepIndex = tutorialStepIndex - 1;
+    const currentTutorialStep = tutorial.getStep(tutorialStepIndex);
+
+    const selectNextTutorial = () => {
+        if (tutorial.hasStep(nextStepIndex)) {
+            setTutorialStepIndex(nextStepIndex);
+        } else {
+            setTutorialStepIndex(0);
+            dispatch(selection.actions.selectTutorial(undefined));
+        }
+    };
+
+    return (
+        <TeachingBubble
+            target={`#${currentTutorialStep.targetId}`}
+            styles={{
+                root: {
+                    className: styles.tutorialContainer,
+                    " div": {
+                        // Equivalent to --primary-brand-purple defined in App.module.css
+                        backgroundColor: "#827aa3",
+                        color: "white",
+                    },
+                },
+            }}
+        >
+            <div className={styles.header}>
+                <h4>Tutorial: {tutorial.title}</h4>
+                <h6>
+                    {tutorialStepIndex + 1} / {tutorial.length}
+                </h6>
+            </div>
+            <p>{currentTutorialStep.message}</p>
+            <div className={styles.buttonFooter}>
+                <IconButton
+                    className={classNames(
+                        {
+                            [styles.disabled]: !tutorial.hasStep(previousStepIndex),
+                        },
+                        styles.tutorialStepButton
+                    )}
+                    disabled={!tutorial.hasStep(previousStepIndex)}
+                    iconProps={{ iconName: "CaretSolidLeft" }}
+                    onClick={() => setTutorialStepIndex(previousStepIndex)}
+                />
+                <IconButton
+                    className={styles.tutorialStepButton}
+                    iconProps={{
+                        iconName: tutorial.hasStep(nextStepIndex) ? "CaretSolidRight" : "Checkmark",
+                    }}
+                    onClick={selectNextTutorial}
+                />
+            </div>
+        </TeachingBubble>
+    );
+}

--- a/packages/core/components/TutorialTooltip/index.tsx
+++ b/packages/core/components/TutorialTooltip/index.tsx
@@ -66,7 +66,12 @@ export default function TutorialTooltip() {
                     onClick={() => setTutorialStepIndex(previousStepIndex)}
                 />
                 <IconButton
-                    className={styles.tutorialStepButton}
+                    className={classNames(
+                        {
+                            [styles.biggerIcon]: !tutorial.hasStep(nextStepIndex),
+                        },
+                        styles.tutorialStepButton
+                    )}
                     iconProps={{
                         iconName: tutorial.hasStep(nextStepIndex) ? "CaretSolidRight" : "Checkmark",
                     }}

--- a/packages/core/components/TutorialTooltip/index.tsx
+++ b/packages/core/components/TutorialTooltip/index.tsx
@@ -64,6 +64,7 @@ export default function TutorialTooltip() {
                     disabled={!tutorial.hasStep(previousStepIndex)}
                     iconProps={{ iconName: "CaretSolidLeft" }}
                     onClick={() => setTutorialStepIndex(previousStepIndex)}
+                    title="Previous step"
                 />
                 <IconButton
                     className={classNames(
@@ -76,6 +77,7 @@ export default function TutorialTooltip() {
                         iconName: tutorial.hasStep(nextStepIndex) ? "CaretSolidRight" : "Checkmark",
                     }}
                     onClick={selectNextTutorial}
+                    title={tutorial.hasStep(nextStepIndex) ? "Next step" : "Finished"}
                 />
             </div>
         </TeachingBubble>

--- a/packages/core/components/TutorialTooltip/test/TutorialTooltip.test.tsx
+++ b/packages/core/components/TutorialTooltip/test/TutorialTooltip.test.tsx
@@ -1,0 +1,94 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { fireEvent, render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+
+import TutorialTooltip from "..";
+import Tutorial from "../../../entity/Tutorial";
+import { initialState, reducer, reduxLogics } from "../../../state";
+
+describe("<TutorialTooltip />", () => {
+    it("pages through tutorial steps", () => {
+        // Arrange
+        const title = "test tutorial";
+        const targetId = "test-id-for-tutorial";
+        const stepOneMessage = "my first message";
+        const stepTwoMessage = "my second message";
+
+        const state = mergeState(initialState, {
+            selection: {
+                tutorial: new Tutorial(title)
+                    .addStep({
+                        targetId,
+                        message: stepOneMessage,
+                    })
+                    .addStep({
+                        targetId,
+                        message: stepTwoMessage,
+                    }),
+            },
+        });
+        const { store } = configureMockStore({ state });
+        const { getByText, getByTitle } = render(
+            <Provider store={store}>
+                <div id={targetId} />
+                <TutorialTooltip />
+            </Provider>
+        );
+
+        // (sanity-check)
+        expect(getByText(stepOneMessage)).to.exist;
+        expect(() => getByText(stepTwoMessage)).to.throw();
+
+        // Act
+        fireEvent.click(getByTitle("Next step"));
+
+        // Assert
+        expect(getByText(stepTwoMessage)).to.exist;
+        expect(() => getByText(stepOneMessage)).to.throw();
+
+        // Act
+        fireEvent.click(getByTitle("Previous step"));
+
+        // Assert
+        expect(getByText(stepOneMessage)).to.exist;
+        expect(() => getByText(stepTwoMessage)).to.throw();
+    });
+
+    it("closes at end of tutorial", () => {
+        // Arrange
+        const title = "My Tutorial";
+        const formattedTutorial = `Tutorial: ${title}`;
+        const targetId = "test-id-for-tutorial";
+
+        const state = mergeState(initialState, {
+            selection: {
+                tutorial: new Tutorial(title).addStep({
+                    targetId,
+                    message: "cool tutorial for you",
+                }),
+            },
+        });
+        const { store } = configureMockStore({
+            logics: reduxLogics,
+            state,
+            reducer,
+        });
+        const { getByText, getByTitle } = render(
+            <Provider store={store}>
+                <div id={targetId} />
+                <TutorialTooltip />
+            </Provider>
+        );
+
+        // (sanity-check)
+        expect(getByText(formattedTutorial)).to.exist;
+
+        // Act
+        fireEvent.click(getByTitle("Finished"));
+
+        // Assert
+        expect(() => getByText(formattedTutorial)).to.throw();
+    });
+});

--- a/packages/core/entity/Tutorial/index.ts
+++ b/packages/core/entity/Tutorial/index.ts
@@ -7,7 +7,8 @@ interface TutorialStep {
 
 /**
  * Entity responsible for containing information about a tutorial in which to guide
- * a user through
+ * a user through. The "targetId" on each step is what the <TutorialTooltip /> uses to
+ * find and display the corresponding "message".
  */
 export default class Tutorial {
     public static readonly ANNOTATION_HIERARCHY_ID = "annotation-hierarchy";

--- a/packages/core/entity/Tutorial/index.ts
+++ b/packages/core/entity/Tutorial/index.ts
@@ -1,0 +1,51 @@
+import { castArray } from "lodash";
+
+interface TutorialStep {
+    targetId: string;
+    message: string | React.ReactNode;
+}
+
+/**
+ * Entity responsible for containing information about a tutorial in which to guide
+ * a user through
+ */
+export default class Tutorial {
+    public static readonly ANNOTATION_HIERARCHY_ID = "annotation-hierarchy";
+    public static readonly ANNOTATION_LIST_ID = "annotation-list";
+    public static readonly COLLECTIONS_TITLE_ID = "collections-title";
+    public static readonly COLUMN_HEADERS_ID = "column-headers";
+    public static readonly COPY_URL_BUTTON_ID = "copy-url-button";
+    public static readonly FILE_ATTRIBUTE_FILTER_ID = "file-attribute-filter";
+    public static readonly FILE_LIST_ID = "file-list";
+    public static readonly URL_BOX_ID = "url-box";
+    public static readonly VIEWS_TITLE_ID = "views-title";
+
+    public readonly title: string;
+    private steps: TutorialStep[];
+
+    public constructor(title: string, steps: TutorialStep[] = []) {
+        this.title = title;
+        this.steps = steps;
+    }
+
+    public get length(): number {
+        return this.steps.length;
+    }
+
+    public hasStep(index: number): boolean {
+        return index > 0 && index < this.steps.length;
+    }
+
+    public getStep(index: number): TutorialStep {
+        return this.steps[index];
+    }
+
+    public addStep(step: TutorialStep | TutorialStep[]): Tutorial {
+        this.steps = [...this.steps, ...castArray(step)];
+        return this;
+    }
+
+    public toString(): string {
+        return `<Tutorial(title: ${this.title}, steps: ${this.steps})>`;
+    }
+}

--- a/packages/core/entity/Tutorial/index.ts
+++ b/packages/core/entity/Tutorial/index.ts
@@ -33,7 +33,7 @@ export default class Tutorial {
     }
 
     public hasStep(index: number): boolean {
-        return index > 0 && index < this.steps.length;
+        return index >= 0 && index < this.steps.length;
     }
 
     public getStep(index: number): TutorialStep {
@@ -46,6 +46,6 @@ export default class Tutorial {
     }
 
     public toString(): string {
-        return `<Tutorial(title: ${this.title}, steps: ${this.steps})>`;
+        return `<Tutorial(title: ${this.title}, steps: ${JSON.stringify(this.steps)})>`;
     }
 }

--- a/packages/core/entity/Tutorial/test/Tutorial.test.ts
+++ b/packages/core/entity/Tutorial/test/Tutorial.test.ts
@@ -1,0 +1,126 @@
+import { expect } from "chai";
+
+import Tutorial from "..";
+
+describe("Tutorial", () => {
+    describe("hasStep", () => {
+        const tutorial = new Tutorial("getStepTutorial")
+            .addStep({
+                targetId: "a",
+                message: "first step",
+            })
+            .addStep({
+                targetId: "b",
+                message: "second step",
+            })
+            .addStep({
+                targetId: "c",
+                message: "third step",
+            });
+        [
+            {
+                test: 0,
+                expect: true,
+            },
+            {
+                test: 2,
+                expect: true,
+            },
+            {
+                test: -1,
+                expect: false,
+            },
+            {
+                test: 4,
+                expect: false,
+            },
+        ].forEach((testCase) => {
+            it(`returns ${testCase.expect} for ${testCase.test}`, () => {
+                expect(tutorial.hasStep(testCase.test)).to.equal(testCase.expect);
+            });
+        });
+    });
+
+    describe("getStep", () => {
+        const steps = [
+            {
+                targetId: "a",
+                message: "first step",
+            },
+            {
+                targetId: "b",
+                message: "second step",
+            },
+            {
+                targetId: "c",
+                message: "third step",
+            },
+            {
+                targetId: "d",
+                message: "fourth step",
+            },
+        ];
+        const tutorial = new Tutorial("getStepTutorial");
+        steps.forEach((step) => {
+            tutorial.addStep(step);
+        });
+
+        steps.forEach((expected, idx) => {
+            it(`returns step number ${idx}`, () => {
+                // Act
+                const actual = tutorial.getStep(idx);
+
+                // Assert
+                expect(actual).to.equal(expected);
+            });
+        });
+    });
+
+    describe("addStep", () => {
+        it("adds to length of tutorial", () => {
+            // Arrange
+            const tutorial = new Tutorial("title").addStep({ targetId: "x", message: "1" });
+
+            // Assert
+            expect(tutorial.length).to.equal(1);
+            tutorial.addStep({ targetId: "x", message: "second step!" });
+            expect(tutorial.length).to.equal(2);
+        });
+
+        it("sets expected step", () => {
+            // Arrange
+            const secondStep = { targetId: "x", message: "second step!" };
+            const tutorial = new Tutorial("title")
+                .addStep({ targetId: "x", message: "1" })
+                .addStep(secondStep);
+
+            // Assert
+            expect(tutorial.getStep(1)).to.equal(secondStep);
+        });
+    });
+
+    describe("toString", () => {
+        [
+            {
+                test: new Tutorial("Title 1").addStep({ targetId: "x", message: "first step" }),
+                expect:
+                    '<Tutorial(title: Title 1, steps: [{"targetId":"x","message":"first step"}])>',
+            },
+            {
+                test: new Tutorial("Title 2")
+                    .addStep({ targetId: "x", message: "first step" })
+                    .addStep({ targetId: "s", message: "second step" }),
+                expect:
+                    '<Tutorial(title: Title 2, steps: [{"targetId":"x","message":"first step"},{"targetId":"s","message":"second step"}])>',
+            },
+            {
+                test: new Tutorial("Title 3"),
+                expect: "<Tutorial(title: Title 3, steps: [])>",
+            },
+        ].forEach((testCase) => {
+            it(`returns ${testCase.expect} for ${testCase.test}`, () => {
+                expect(testCase.test.toString()).to.equal(testCase.expect);
+            });
+        });
+    });
+});

--- a/packages/core/services/PersistentConfigService/index.ts
+++ b/packages/core/services/PersistentConfigService/index.ts
@@ -5,6 +5,7 @@ export enum PersistedConfigKeys {
     AllenMountPoint = "ALLEN_MOUNT_POINT",
     CsvColumns = "CSV_COLUMNS",
     ImageJExecutable = "IMAGE_J_EXECUTABLE", // Deprecated
+    HasUsedApplicationBefore = "HAS_USED_APPLICATION_BEFORE",
     UserSelectedApplications = "USER_SELECTED_APPLICATIONS",
 }
 
@@ -16,6 +17,7 @@ export interface UserSelectedApplication {
 export interface PersistedConfig {
     [PersistedConfigKeys.CsvColumns]?: string[];
     [PersistedConfigKeys.ImageJExecutable]?: string; // Deprecated
+    [PersistedConfigKeys.HasUsedApplicationBefore]?: boolean;
     [PersistedConfigKeys.UserSelectedApplications]?: UserSelectedApplication[];
 }
 

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -83,6 +83,27 @@ export function downloadFile(fileInfo: FileInfo): DownloadFileAction {
 }
 
 /**
+ * MARK_AS_USED_APPLICATION_BEFORE
+ *
+ * Intention to mark application as having been used by user before
+ */
+
+export const MARK_AS_USED_APPLICATION_BEFORE = makeConstant(
+    STATE_BRANCH_NAME,
+    "mark-as-used-application-before"
+);
+
+export interface MarkAsUsedApplicationBefore {
+    type: string;
+}
+
+export function markAsUsedApplicationBefore(): MarkAsUsedApplicationBefore {
+    return {
+        type: MARK_AS_USED_APPLICATION_BEFORE,
+    };
+}
+
+/**
  * SET_CSV_COLUMNS
  *
  * Intention to set the csv columns
@@ -575,6 +596,26 @@ export function showManifestDownloadDialog(
     return {
         type: SHOW_MANIFEST_DOWNLOAD_DIALOG,
         payload: fileFilters,
+    };
+}
+
+/**
+ * SHOW_TIPS_AND_TRICKS_DIALOG
+ *
+ * Intention to show the tips and tricks dialog.
+ */
+export const SHOW_TIPS_AND_TRICKS_DIALOG = makeConstant(
+    STATE_BRANCH_NAME,
+    "show-tips-and-tricks-dialog"
+);
+
+export interface ShowTipsAndTricksDialogAction {
+    type: string;
+}
+
+export function showTipsAndTricksDialog(): ShowTipsAndTricksDialogAction {
+    return {
+        type: SHOW_TIPS_AND_TRICKS_DIALOG,
     };
 }
 

--- a/packages/core/state/interaction/reducer.ts
+++ b/packages/core/state/interaction/reducer.ts
@@ -22,6 +22,8 @@ import {
     SHOW_EDIT_COLLECTION_DIALOG,
     GENERATE_SHAREABLE_FILE_SELECTION_LINK,
     UPDATE_COLLECTION,
+    MARK_AS_USED_APPLICATION_BEFORE,
+    SHOW_TIPS_AND_TRICKS_DIALOG,
 } from "./actions";
 import { ContextMenuItem, PositionReference } from "../../components/ContextMenu";
 import { ModalType } from "../../components/Modal";
@@ -45,6 +47,7 @@ export interface InteractionStateBranch {
     csvColumns?: string[];
     fileExplorerServiceBaseUrl: string;
     fileFiltersForVisibleModal: FileFilter[];
+    hasUsedApplicationBefore: boolean;
     platformDependentServices: PlatformDependentServices;
     pythonSnippet?: PythonicDataAccessSnippet;
     refreshKey?: string;
@@ -63,6 +66,7 @@ export const initialState = {
     contextMenuPositionReference: null,
     fileExplorerServiceBaseUrl: DEFAULT_CONNECTION_CONFIG.baseUrl,
     fileFiltersForVisibleModal: [],
+    hasUsedApplicationBefore: false,
     platformDependentServices: {
         applicationInfoService: new ApplicationInfoServiceNoop(),
         fileDownloadService: new FileDownloadServiceNoop(),
@@ -82,6 +86,10 @@ export const initialState = {
 
 export default makeReducer<InteractionStateBranch>(
     {
+        [MARK_AS_USED_APPLICATION_BEFORE]: (state) => ({
+            ...state,
+            hasUsedApplicationBefore: true,
+        }),
         [SHOW_CONTEXT_MENU]: (state, action) => ({
             ...state,
             contextMenuIsVisible: true,
@@ -166,6 +174,10 @@ export default makeReducer<InteractionStateBranch>(
             ...state,
             visibleModal: ModalType.CsvManifest,
             fileFiltersForVisibleModal: action.payload,
+        }),
+        [SHOW_TIPS_AND_TRICKS_DIALOG]: (state) => ({
+            ...state,
+            visibleModal: ModalType.TipsAndTricks,
         }),
         [UPDATE_COLLECTION]: (state) => ({
             ...state,

--- a/packages/core/state/interaction/selectors.ts
+++ b/packages/core/state/interaction/selectors.ts
@@ -19,6 +19,8 @@ export const getFileExplorerServiceBaseUrl = (state: State) =>
     state.interaction.fileExplorerServiceBaseUrl;
 export const getFileFiltersForVisibleModal = (state: State) =>
     state.interaction.fileFiltersForVisibleModal;
+export const hasUsedApplicationBefore = (state: State) =>
+    state.interaction.hasUsedApplicationBefore;
 export const getPlatformDependentServices = (state: State) =>
     state.interaction.platformDependentServices;
 export const getProcessStatuses = (state: State) => state.interaction.status;

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -7,6 +7,7 @@ import FileSelection from "../../entity/FileSelection";
 import FileSet from "../../entity/FileSet";
 import FileSort from "../../entity/FileSort";
 import NumericRange from "../../entity/NumericRange";
+import Tutorial from "../../entity/Tutorial";
 import { Dataset } from "../../services/DatasetService";
 
 const STATE_BRANCH_NAME = "selection";
@@ -501,5 +502,24 @@ export function changeCollection(collection?: Dataset): ChangeCollectionAction {
     return {
         payload: collection,
         type: CHANGE_COLLECTION,
+    };
+}
+
+/**
+ * SELECT_TUTORIAL
+ *
+ * Intention to update the current tutorial step displayed to users
+ */
+export const SELECT_TUTORIAL = makeConstant(STATE_BRANCH_NAME, "select-tutorial");
+
+export interface SelectTutorial {
+    payload?: Tutorial;
+    type: string;
+}
+
+export function selectTutorial(tutorial?: Tutorial): SelectTutorial {
+    return {
+        payload: tutorial,
+        type: SELECT_TUTORIAL,
     };
 }

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -22,8 +22,10 @@ import {
     SET_SORT_COLUMN,
     CHANGE_COLLECTION,
     CHANGE_VIEW,
+    SELECT_TUTORIAL,
 } from "./actions";
 import FileSort, { SortOrder } from "../../entity/FileSort";
+import Tutorial from "../../entity/Tutorial";
 import { Dataset } from "../../services/DatasetService";
 
 export interface SelectionStateBranch {
@@ -39,6 +41,7 @@ export interface SelectionStateBranch {
     filters: FileFilter[];
     openFileFolders: FileFolder[];
     sortColumn?: FileSort;
+    tutorial?: Tutorial;
 }
 
 export const initialState = {
@@ -60,6 +63,10 @@ export const initialState = {
 
 export default makeReducer<SelectionStateBranch>(
     {
+        [SELECT_TUTORIAL]: (state, action) => ({
+            ...state,
+            tutorial: action.payload,
+        }),
         [SET_FILE_FILTERS]: (state, action) => ({
             ...state,
             filters: action.payload,

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -22,6 +22,7 @@ export const getCollection = (state: State) => state.selection.collection;
 export const getFileSelection = (state: State) => state.selection.fileSelection;
 export const getOpenFileFolders = (state: State) => state.selection.openFileFolders;
 export const getSortColumn = (state: State) => state.selection.sortColumn;
+export const getTutorial = (state: State) => state.selection.tutorial;
 
 // COMPOSED SELECTORS
 export const getOrderedDisplayAnnotations = createSelector(

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -59,7 +59,9 @@ const collectPlatformDependentServices = memoize(
     })
 );
 
-const frontendInsightsMiddleware = reduxMiddleware(frontendInsights, { useActionAsProperties: true });
+const frontendInsightsMiddleware = reduxMiddleware(frontendInsights, {
+    useActionAsProperties: true,
+});
 const store = createReduxStore({
     middleware: [frontendInsightsMiddleware],
     persistedConfig: persistentConfigService.getAll(),
@@ -69,6 +71,7 @@ store.subscribe(() => {
     const state = store.getState();
     const csvColumns = interaction.selectors.getCsvColumns(state);
     const userSelectedApplications = interaction.selectors.getUserSelectedApplications(state);
+    const hasUsedApplicationBefore = interaction.selectors.hasUsedApplicationBefore(state);
     const appState = {
         [PersistedConfigKeys.CsvColumns]: csvColumns,
         [PersistedConfigKeys.UserSelectedApplications]: userSelectedApplications,
@@ -77,6 +80,7 @@ store.subscribe(() => {
         persistentConfigService.persist({
             [PersistedConfigKeys.CsvColumns]: csvColumns,
             [PersistedConfigKeys.UserSelectedApplications]: userSelectedApplications,
+            [PersistedConfigKeys.HasUsedApplicationBefore]: hasUsedApplicationBefore,
         });
     }
 });

--- a/packages/desktop/src/services/PersistentConfigServiceElectron.ts
+++ b/packages/desktop/src/services/PersistentConfigServiceElectron.ts
@@ -26,6 +26,9 @@ const OPTIONS: Options<Record<string, unknown>> = {
         [PersistedConfigKeys.ImageJExecutable]: {
             type: "string",
         },
+        [PersistedConfigKeys.HasUsedApplicationBefore]: {
+            type: "boolean",
+        },
         [PersistedConfigKeys.UserSelectedApplications]: {
             type: "array",
             items: {

--- a/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
+++ b/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
@@ -37,6 +37,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
             const expectedAllenMountPoint = "/some/path/to/allen";
             const expectedCsvColumns = ["a", "b", "c"];
             const expectedImageJExecutable = "/some/path/to/imageJ";
+            const expectedHasUsedApplicationBefore = true;
             const expectedUserSelectedApps = [
                 {
                     filePath: "/some/path/to/ZEN",
@@ -47,11 +48,16 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
             service.persist(PersistedConfigKeys.AllenMountPoint, expectedAllenMountPoint);
             service.persist(PersistedConfigKeys.CsvColumns, expectedCsvColumns);
             service.persist(PersistedConfigKeys.ImageJExecutable, expectedImageJExecutable);
+            service.persist(
+                PersistedConfigKeys.HasUsedApplicationBefore,
+                expectedHasUsedApplicationBefore
+            );
             service.persist(PersistedConfigKeys.UserSelectedApplications, expectedUserSelectedApps);
             const expectedConfig = {
                 [PersistedConfigKeys.AllenMountPoint]: expectedAllenMountPoint,
                 [PersistedConfigKeys.CsvColumns]: expectedCsvColumns,
                 [PersistedConfigKeys.ImageJExecutable]: expectedImageJExecutable,
+                [PersistedConfigKeys.HasUsedApplicationBefore]: expectedHasUsedApplicationBefore,
                 [PersistedConfigKeys.UserSelectedApplications]: expectedUserSelectedApps,
             };
 
@@ -71,6 +77,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                 [PersistedConfigKeys.AllenMountPoint]: "/some/path/to/allen",
                 [PersistedConfigKeys.CsvColumns]: ["a", "b"],
                 [PersistedConfigKeys.ImageJExecutable]: "/my/imagej",
+                [PersistedConfigKeys.HasUsedApplicationBefore]: undefined,
                 [PersistedConfigKeys.UserSelectedApplications]: [
                     {
                         filePath: "/some/path/to/ImageJ",


### PR DESCRIPTION
This PR adds an embedded tutorial system meant to help both expose and encourage feature use. Additionally, our existing tutorials were difficult to keep up to date and required significant time both from us and the users. Now to add a tutorial you create a `Tutorial` entity and append some steps where the `targetId`s correponding to the HTML id attributes of the component you want to point to, afterward add the `Tutorial` constant to the Tutorials dropdown list.

Included as part of this was adding a "Help" section with some helpful links & a tips and tricks section that could use some more tips and tricks, but I included it as a start.

**Testing**
Locally and some unit tests

https://user-images.githubusercontent.com/41307451/220770815-054f21fc-3bd0-4573-a89a-ba1d951d173c.mov


