### PR TITLE
[SWE-770] Fix fuzzy search and add some UX improvements

### DIFF
--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -76,6 +76,19 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
         dispatch(selection.actions.addFileFilter(fileFilter));
     };
 
+    const onSelectAll = () => {
+        const filters = items.map(
+            (item) =>
+                new FileFilter(
+                    annotationName,
+                    isNil(annotation?.valueOf(item.value))
+                        ? item.value
+                        : annotation?.valueOf(item.value)
+                )
+        );
+        dispatch(selection.actions.addFileFilter(filters));
+    };
+
     // TODO, return different pickers based on annotation type
     // e.g., a date picker, a range (numeric) picker, etc.
     switch (annotation?.type) {
@@ -90,6 +103,7 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
                     onDeselect={onDeselect}
                     onDeselectAll={onDeselectAll}
                     onSelect={onSelect}
+                    onSelectAll={onSelectAll}
                 />
             );
     }

--- a/packages/core/components/ListPicker/ListPicker.module.css
+++ b/packages/core/components/ListPicker/ListPicker.module.css
@@ -3,7 +3,7 @@
 
     overflow: auto;
     max-height: 300px;
-    padding: 0 var(--spacing) var(--spacing) var(--spacing);
+    padding: 0 var(--spacing) 0 var(--spacing);
     margin-top: var(--spacing);
 }
 
@@ -15,11 +15,37 @@
     background: rgba(255, 255, 255, 0.85);
 }
 
+.buttons {
+    display: flex;
+}
+
+.footer {
+    bottom: 0;
+    padding-bottom: var(--spacing);
+    position: sticky;
+    width: 100%;
+}
+
+.footer > h6 {
+    background-color: white;
+    border-radius: 5px;
+    color: grey;
+    font-size: 12px;
+    font-weight: normal;
+    margin: 0 0 0 auto;
+    width: fit-content;
+}
+
 .action-button {
     color: steelblue;
     cursor: pointer;
     display: flex;
     margin: 0.5rem auto 0;
+}
+
+.action-button.disabled {
+    color: grey;
+    cursor: not-allowed;
 }
 
 .item {

--- a/packages/core/components/ListPicker/test/ListPicker.test.tsx
+++ b/packages/core/components/ListPicker/test/ListPicker.test.tsx
@@ -99,4 +99,42 @@ describe("<ListPicker />", () => {
         fireEvent.click(getByText("Reset"));
         expect(onDeselectAll.called).to.equal(true);
     });
+
+    it("Renders a 'Select All' button if given a callback for selecting all items", () => {
+        // Arrange
+        const onSelectAll = sinon.spy();
+        const items: ListItem[] = ["foo", "bar"].map((val) => ({
+            selected: true, // start with all items selected
+            displayValue: val,
+            value: val,
+        }));
+        const { getAllByRole, getByText } = render(
+            <ListPicker items={items} onDeselect={noop} onSelectAll={onSelectAll} onSelect={noop} />
+        );
+
+        // (sanity-check)
+        expect(getAllByRole("checkbox", { checked: true }).length).to.equal(2);
+        expect(onSelectAll.called).to.be.false;
+
+        // Act
+        fireEvent.click(getByText("Select All"));
+
+        // Assert
+        expect(onSelectAll.called).to.be.true;
+    });
+
+    it("Displays count of items", () => {
+        // Arrange
+        const items: ListItem[] = ["foo", "bar"].map((val) => ({
+            selected: true, // start with all items selected
+            displayValue: val,
+            value: val,
+        }));
+        const { getByText } = render(
+            <ListPicker items={items} onDeselect={noop} onSelect={noop} />
+        );
+
+        // Act / Assert
+        expect(getByText(`Displaying ${items.length} of ${items.length} Options`)).to.exist;
+    });
 });


### PR DESCRIPTION
The fuzzy search for the items in the ListPicker was a little to strict in its search and not finding very accurate results for many annotations. This update changes the fuzzy search config, adds a count UI element, and a "Select All" option since while I was there I was finding myself wanting those and they were a simple add.