### PR TITLE
Feature/swe 776 download feature upgrade

### DIFF
--- a/packages/core/components/ContextMenu/items.ts
+++ b/packages/core/components/ContextMenu/items.ts
@@ -98,7 +98,7 @@ export default function getContextMenuItems(dispatch: Dispatch) {
                 text: "Download",
                 title: "Download selected files",
                 onClick() {
-                    dispatch(interaction.actions.downloadSelectedFiles());
+                    dispatch(interaction.actions.downloadFiles());
                 },
             },
         ],

--- a/packages/core/components/ContextMenu/items.ts
+++ b/packages/core/components/ContextMenu/items.ts
@@ -8,6 +8,7 @@ export enum ContextMenuActions {
     CSV_MANIFEST = "csv-manifest",
     CUSTOM_COLLECTION = "custom-collection",
     DEFAULT_COLLECTION = "default-collection",
+    DOWNLOAD = "download",
     MODIFY_COLUMNS = "modify-columns",
     OPEN = "open",
     OPEN_WITH = "open-with",
@@ -90,6 +91,14 @@ export default function getContextMenuItems(dispatch: Dispatch) {
                 title: "CSV file of metadata of selected files",
                 onClick() {
                     dispatch(interaction.actions.showManifestDownloadDialog());
+                },
+            },
+            {
+                key: ContextMenuActions.DOWNLOAD,
+                text: "Download",
+                title: "Download selected files",
+                onClick() {
+                    dispatch(interaction.actions.downloadSelectedFiles());
                 },
             },
         ],

--- a/packages/core/components/FileDetails/Download.tsx
+++ b/packages/core/components/FileDetails/Download.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from "@fluentui/react";
+import { ActionButton, IButtonStyles } from "@fluentui/react";
 import { throttle } from "lodash";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -7,20 +7,9 @@ import { interaction } from "../../state";
 import FileDetail from "../../entity/FileDetail";
 
 interface DownloadProps {
+    buttonStyles?: IButtonStyles;
     fileDetails: FileDetail | null;
 }
-
-const ICON_BUTTON_STYLES = {
-    icon: {
-        color: "black",
-        fontSize: "13px",
-    },
-    root: {
-        background: "none",
-        height: 24,
-        width: 24,
-    },
-};
 
 /**
  * Button for dispatching an event declaring intention to download a file.
@@ -32,7 +21,7 @@ export default function Download(props: DownloadProps) {
     const processStatuses = useSelector(interaction.selectors.getProcessStatuses);
 
     // Prevent triggering multiple downloads accidentally -- throttle with a 1s wait
-    const onClick = React.useMemo(() => {
+    const onDownload = React.useMemo(() => {
         if (!fileDetails) {
             return () => {
                 /** noop */
@@ -40,14 +29,7 @@ export default function Download(props: DownloadProps) {
         }
 
         return throttle(() => {
-            dispatch(
-                interaction.actions.downloadFile({
-                    id: fileDetails.id,
-                    name: fileDetails.name,
-                    path: fileDetails.path,
-                    size: fileDetails.size,
-                })
-            );
+            dispatch(interaction.actions.downloadFiles([fileDetails.details]));
         }, 1000); // 1s, in ms (arbitrary)
     }, [dispatch, fileDetails]);
 
@@ -56,15 +38,16 @@ export default function Download(props: DownloadProps) {
     }
 
     return (
-        <IconButton
+        <ActionButton
             ariaLabel="Download file"
+            iconProps={{ iconName: "Download" }}
             disabled={processStatuses.some((status) =>
                 status.data.fileId?.includes(fileDetails.id)
             )}
-            iconProps={{ iconName: "Download" }}
-            onClick={onClick}
-            styles={ICON_BUTTON_STYLES}
-            title="Download file"
+            onClick={onDownload}
+            styles={props.buttonStyles}
+            title="Download"
+            text="Download"
         />
     );
 }

--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -83,11 +83,29 @@
 }
 
 .file-actions {
-    padding: var(--padding);
+    padding: 0 var(--padding) 0 var(--padding);
 
     /* flex parent */
     display: flex;
-    justify-content: flex-end;
+}
+
+.file-actions button {
+    background-color: darkgrey;
+    font-size: 12px;
+}
+
+.file-actions > * {
+    margin: 0 5px 0 5px;
+}
+
+.file-actions > *:first-child {
+    border-radius: 10px 0 0 10px;
+    margin-left: 0;
+}
+
+.file-actions > *:last-child {
+    margin-right: 0;
+    width: 100%;
 }
 
 .annotation-list {

--- a/packages/core/components/FileDetails/OpenFileButton.module.css
+++ b/packages/core/components/FileDetails/OpenFileButton.module.css
@@ -1,0 +1,3 @@
+.command-button {
+    border-radius: 0;
+}

--- a/packages/core/components/FileDetails/OpenFileButton.tsx
+++ b/packages/core/components/FileDetails/OpenFileButton.tsx
@@ -1,0 +1,95 @@
+import {
+    CommandButton,
+    ContextualMenuItemType,
+    IButtonStyles,
+    IContextualMenuProps,
+} from "@fluentui/react";
+import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { interaction } from "../../state";
+import FileDetail from "../../entity/FileDetail";
+import FileFilter from "../../entity/FileFilter";
+
+import styles from "./OpenFileButton.module.css";
+
+interface Props {
+    buttonStyles?: IButtonStyles;
+    fileDetails: FileDetail | null;
+}
+
+/**
+ * Button for dispatching open file actions.
+ */
+export default function OpenFileButton(props: Props) {
+    const { fileDetails } = props;
+
+    const dispatch = useDispatch();
+    const userSelectedApplications =
+        useSelector(interaction.selectors.getUserSelectedApplications) || [];
+    const { executionEnvService } = useSelector(interaction.selectors.getPlatformDependentServices);
+
+    const openMenuProps: IContextualMenuProps = React.useMemo(() => {
+        if (!fileDetails) {
+            return { items: [] };
+        }
+
+        return {
+            items: [
+                ...userSelectedApplications
+                    .map((app) => ({ ...app, name: executionEnvService.getFilename(app.filePath) }))
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((app) => ({
+                        key: `open-with-${app.name}`,
+                        text: app.name,
+                        title: `Open files with ${app.name}`,
+                        onClick() {
+                            dispatch(
+                                interaction.actions.openWith(app, undefined, [fileDetails.details])
+                            );
+                        },
+                    })),
+                ...(userSelectedApplications.length > 0
+                    ? [
+                          {
+                              key: "default-apps-border",
+                              itemType: ContextualMenuItemType.Divider,
+                          },
+                      ]
+                    : []),
+                // Other is a permanent option that allows the user
+                // to add another app for file access
+                {
+                    key: "Other...",
+                    text: "Other...",
+                    title: "Select an application to open the selection with",
+                    onClick() {
+                        dispatch(
+                            interaction.actions.promptForNewExecutable([
+                                new FileFilter("file_id", fileDetails.id),
+                            ])
+                        );
+                    },
+                },
+            ],
+        };
+    }, [dispatch, fileDetails, userSelectedApplications, executionEnvService]);
+
+    if (!fileDetails) {
+        return null;
+    }
+
+    return (
+        <CommandButton
+            split
+            className={styles.commandButton}
+            menuProps={openMenuProps}
+            onClick={() =>
+                dispatch(interaction.actions.openWithDefault(undefined, [fileDetails.details]))
+            }
+            text="Open"
+            title="Open with default"
+            styles={props.buttonStyles}
+        />
+    );
+}

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -1,3 +1,4 @@
+import { IButtonStyles } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -7,6 +8,7 @@ import useFileDetails from "./useFileDetails";
 import windowStateReducer, { INITIAL_STATE, WindowState } from "./windowStateReducer";
 import Download from "./Download";
 import FileAnnotationList from "./FileAnnotationList";
+import OpenFileButton from "./OpenFileButton";
 import Pagination from "./Pagination";
 import { ROOT_ELEMENT_ID } from "../../App";
 import SvgIcon from "../../components/SvgIcon";
@@ -25,6 +27,48 @@ const windowStateToClassnameMap: { [index: string]: string } = {
 };
 
 export const WINDOW_ACTION_BUTTON_WIDTH = 23; // arbitrary
+
+const ICON_BUTTON_STYLES: IButtonStyles = {
+    icon: {
+        color: "black",
+        fontSize: "12px",
+    },
+    label: {
+        width: "100%",
+    },
+    root: {
+        background: "none",
+        height: 24,
+        width: "100%",
+        ":hover, :hover *": {
+            backgroundColor: "#878787",
+            color: "white",
+        },
+    },
+    iconHovered: {
+        backgroundColor: "#878787",
+        color: "white",
+    },
+    splitButtonMenuButton: {
+        border: "None",
+        borderLeft: "black 1px solid",
+        borderBottomRightRadius: "10px",
+        borderTopRightRadius: "10px",
+        paddingLeft: "2px",
+        ":hover, :hover *": {
+            backgroundColor: "#878787",
+            color: "white",
+            cursor: "pointer",
+        },
+    },
+    splitButtonMenuIcon: {
+        color: "black",
+        fontSize: "10px",
+    },
+    textContainer: {
+        width: "100%",
+    },
+};
 
 const FILE_DETAILS_PANE_ID = "file-details-pane";
 const FILE_DETAILS_WIDTH_ATTRIBUTE = "--file-details-width";
@@ -186,7 +230,14 @@ export default function FileDetails(props: FileDetails) {
                         >
                             {fileDetails && thumbnail}
                             <div className={styles.fileActions}>
-                                <Download fileDetails={fileDetails} />
+                                <Download
+                                    buttonStyles={ICON_BUTTON_STYLES}
+                                    fileDetails={fileDetails}
+                                />
+                                <OpenFileButton
+                                    buttonStyles={ICON_BUTTON_STYLES}
+                                    fileDetails={fileDetails}
+                                />
                             </div>
                             <FileAnnotationList
                                 className={styles.annotationList}

--- a/packages/core/components/FileDetails/test/Download.test.tsx
+++ b/packages/core/components/FileDetails/test/Download.test.tsx
@@ -37,7 +37,7 @@ describe("<Download />", () => {
         expect(actions.list.length).to.equal(1);
         expect(
             actions.includesMatch({
-                type: interaction.actions.DOWNLOAD_FILE,
+                type: interaction.actions.DOWNLOAD_FILES,
             })
         ).to.equal(true);
     });
@@ -72,7 +72,7 @@ describe("<Download />", () => {
         expect(actions.list.length).to.equal(1);
         expect(
             actions.includesMatch({
-                type: interaction.actions.DOWNLOAD_FILE,
+                type: interaction.actions.DOWNLOAD_FILES,
             })
         ).to.equal(true);
     });

--- a/packages/core/components/FileDetails/test/OpenFileButton.test.tsx
+++ b/packages/core/components/FileDetails/test/OpenFileButton.test.tsx
@@ -1,0 +1,44 @@
+import { configureMockStore } from "@aics/redux-utils";
+import { fireEvent, render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+
+import { initialState, interaction } from "../../../state";
+import FileDetail from "../../../entity/FileDetail";
+import OpenFileButton from "../OpenFileButton";
+
+describe("<OpenFileButton />", () => {
+    it("opens file in app", () => {
+        // Arrange
+        const { store, actions } = configureMockStore({ state: initialState });
+        const fileDetails = new FileDetail({
+            file_path: "/allen/some/path/MyFile.txt",
+            file_id: "abc123",
+            file_name: "MyFile.txt",
+            file_size: 7,
+            uploaded: "01/01/01",
+            annotations: [],
+        });
+
+        const { getByText } = render(
+            <Provider store={store}>
+                <OpenFileButton fileDetails={fileDetails} />
+            </Provider>
+        );
+
+        // (sanity-check) no actions fired
+        expect(actions.list.length).to.equal(0);
+
+        // Act
+        fireEvent.click(getByText("Open"));
+
+        // Assert
+        expect(actions.list.length).to.equal(1);
+        expect(
+            actions.includesMatch({
+                type: interaction.actions.OPEN_WITH_DEFAULT,
+            })
+        ).to.be.true;
+    });
+});

--- a/packages/core/components/HeaderRibbon/test/CollectionControl.test.tsx
+++ b/packages/core/components/HeaderRibbon/test/CollectionControl.test.tsx
@@ -141,7 +141,7 @@ describe("<CollectionControl />", () => {
         );
 
         // Assert
-        expect(getByText("Public")).to.exist;
+        expect(getByText("Internal")).to.exist;
         expect(getByText("Not Frozen")).to.exist;
     });
 });

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -83,6 +83,23 @@ export function downloadFile(fileInfo: FileInfo): DownloadFileAction {
 }
 
 /**
+ * DOWNLOAD_SELECTED_FILES
+ *
+ * Intention to download selected files to local disk.
+ */
+export const DOWNLOAD_SELECTED_FILES = makeConstant(STATE_BRANCH_NAME, "download-selected-files");
+
+export interface DownloadSelectedFilesAction {
+    type: string;
+}
+
+export function downloadSelectedFiles(): DownloadSelectedFilesAction {
+    return {
+        type: DOWNLOAD_SELECTED_FILES,
+    };
+}
+
+/**
  * SET_CSV_COLUMNS
  *
  * Intention to set the csv columns

--- a/packages/core/state/interaction/actions.ts
+++ b/packages/core/state/interaction/actions.ts
@@ -7,7 +7,7 @@ import ApplicationInfoService from "../../services/ApplicationInfoService";
 import { ContextMenuItem, PositionReference } from "../../components/ContextMenu";
 import { Dataset, PythonicDataAccessSnippet } from "../../services/DatasetService";
 import ExecutionEnvService from "../../services/ExecutionEnvService";
-import FileDownloadService, { FileInfo } from "../../services/FileDownloadService";
+import FileDownloadService from "../../services/FileDownloadService";
 import FileFilter from "../../entity/FileFilter";
 import FileViewerService from "../../services/FileViewerService";
 import { ModalType } from "../../components/Modal";
@@ -64,38 +64,21 @@ export function cancelFileDownload(id: string): CancelFileDownloadAction {
 }
 
 /**
- * DOWNLOAD_FILE
+ * DOWNLOAD_FILES
  *
- * Intention to download a file to local disk.
+ * Intention to download files to local disk.
  */
-export const DOWNLOAD_FILE = makeConstant(STATE_BRANCH_NAME, "download-file");
+export const DOWNLOAD_FILES = makeConstant(STATE_BRANCH_NAME, "download-files");
 
-export interface DownloadFileAction {
-    payload: FileInfo;
+export interface DownloadFilesAction {
+    payload?: FmsFile[];
     type: string;
 }
 
-export function downloadFile(fileInfo: FileInfo): DownloadFileAction {
+export function downloadFiles(files?: FmsFile[]): DownloadFilesAction {
     return {
-        payload: fileInfo,
-        type: DOWNLOAD_FILE,
-    };
-}
-
-/**
- * DOWNLOAD_SELECTED_FILES
- *
- * Intention to download selected files to local disk.
- */
-export const DOWNLOAD_SELECTED_FILES = makeConstant(STATE_BRANCH_NAME, "download-selected-files");
-
-export interface DownloadSelectedFilesAction {
-    type: string;
-}
-
-export function downloadSelectedFiles(): DownloadSelectedFilesAction {
-    return {
-        type: DOWNLOAD_SELECTED_FILES,
+        payload: files,
+        type: DOWNLOAD_FILES,
     };
 }
 
@@ -650,13 +633,16 @@ export function setUserSelectedApplication(
 export const OPEN_WITH_DEFAULT = makeConstant(STATE_BRANCH_NAME, "open-with-default");
 
 export interface OpenWithDefaultAction {
-    payload?: FileFilter[];
+    payload: {
+        files?: FmsFile[];
+        filters?: FileFilter[];
+    };
     type: string;
 }
 
-export function openWithDefault(filters?: FileFilter[]): OpenWithDefaultAction {
+export function openWithDefault(filters?: FileFilter[], files?: FmsFile[]): OpenWithDefaultAction {
     return {
-        payload: filters,
+        payload: { files, filters },
         type: OPEN_WITH_DEFAULT,
     };
 }

--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -270,6 +270,103 @@ const downloadFile = createLogic({
     },
 });
 
+/**
+ * Interceptor responsible for responding to a DOWNLOAD_FILES action and
+ * initiating the downloads of the selected files, showing notifications of process status along the way.
+ */
+// const downloadSelectedFiles = createLogic({
+//     type: DOWNLOAD_SELECTED_FILES,
+//     warnTimeout: 0, // no way to know how long this will take--don't print console warning if it takes a while
+//     async process(deps: ReduxLogicDeps, dispatch, done) {
+//         // TODO: Consider this applying to DOWNLOAD_FILE too like how OPEN_WITH works
+//         const fileService = interactionSelectors.getFileService(deps.getState());
+//         const fileSelection = selection.selectors.getFileSelection(deps.getState());
+//         const {
+//             fileDownloadService,
+//             executionEnvService,
+//         } = interactionSelectors.getPlatformDependentServices(deps.getState());
+//         const sortColumn = selection.selectors.getSortColumn(deps.getState());
+
+//         const numberFormatter = annotationFormatterFactory(AnnotationType.NUMBER);
+
+//         let filesToOpen;
+//         if (files) {
+//             filesToOpen = files;
+//         } else if (filters) {
+//             const fileSet = new FileSet({
+//                 filters,
+//                 fileService,
+//                 sort: sortColumn,
+//             });
+//             const totalFileCount = await fileSet.fetchTotalCount();
+//             filesToOpen = await fileSet.fetchFileRange(0, totalFileCount);
+//         } else {
+//             filesToOpen = await fileSelection.fetchAllDetails();
+//         }
+//         const filePaths = await Promise.all(
+//             // TODO: Need this function out of the executation env???
+//             filesToOpen.map(
+//                 async (file) => await executionEnvService.formatPathForHost(file.file_path)
+//             )
+//         );
+
+//         filePaths.forEach(filePath => {
+//             const downloadRequestId = uniqueId();
+//             const msg = `Downloading ${fileInfo.name}, ${numberFormatter.displayValue(
+//                 fileInfo.size,
+//                 "bytes"
+//             )} in total`;
+
+//             const onCancel = () => {
+//                 dispatch(cancelFileDownload(downloadRequestId));
+//             };
+
+//             let totalBytesDownloaded = 0;
+//             // A function that dispatches progress events, throttled
+//             // to only be invokable at most once/second
+//             const throttledProgressDispatcher = throttle(() => {
+//                 dispatch(
+//                     processProgress(
+//                         downloadRequestId,
+//                         totalBytesDownloaded / fileInfo.size,
+//                         msg,
+//                         onCancel,
+//                         [fileInfo.id]
+//                     )
+//                 );
+//             }, 1000);
+//             const onProgress = (transferredBytes: number) => {
+//                 totalBytesDownloaded += transferredBytes;
+//                 throttledProgressDispatcher();
+//             };
+
+//             try {
+//                 dispatch(processStart(downloadRequestId, msg, onCancel, [fileInfo.id]));
+
+//                 const result = await fileDownloadService.downloadFile(
+//                     fileInfo,
+//                     downloadRequestId,
+//                     onProgress
+//                 );
+
+//                 if (result.resolution === DownloadResolution.CANCELLED) {
+//                     // Clear status if request was cancelled
+//                     dispatch(removeStatus(downloadRequestId));
+//                 } else {
+//                     dispatch(processSuccess(downloadRequestId, result.msg || ""));
+//                 }
+//             } catch (err) {
+//                 const errorMsg = `File download failed. Details:<br/>${
+//                     err instanceof Error ? err.message : err
+//                 }`;
+//                 dispatch(processFailure(downloadRequestId, errorMsg));
+//             }
+//         })
+
+//         done();
+//     }
+// });
+
 const promptForNewExecutable = createLogic({
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const {
@@ -655,6 +752,7 @@ export default [
     openWithLogic,
     promptForNewExecutable,
     downloadFile,
+    // downloadSelectedFiles,
     showContextMenu,
     updateCollection,
     generateShareableFileSelectionLink,

--- a/packages/core/state/interaction/test/logics.test.ts
+++ b/packages/core/state/interaction/test/logics.test.ts
@@ -24,7 +24,7 @@ import {
     SET_USER_SELECTED_APPLICATIONS,
     promptForNewExecutable,
     openWithDefault,
-    downloadFile,
+    downloadFiles,
     generateShareableFileSelectionLink,
     SUCCEED_SHAREABLE_FILE_SELECTION_LINK_GENERATION,
 } from "../actions";
@@ -283,7 +283,7 @@ describe("Interaction logics", () => {
         });
     });
 
-    describe("downloadFile", () => {
+    describe("downloadFiles", () => {
         const sandbox = createSandbox();
 
         afterEach(() => {
@@ -303,16 +303,17 @@ describe("Interaction logics", () => {
                 state,
                 logics: interactionLogics,
             });
+            const file: FmsFile = {
+                file_id: "678142",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
 
             // Act
-            store.dispatch(
-                downloadFile({
-                    id: "abc123",
-                    name: "foo.ext",
-                    path: "/some/path/foo.ext",
-                    size: 5,
-                })
-            );
+            store.dispatch(downloadFiles([file]));
             await logicMiddleware.whenComplete();
 
             // Assert
@@ -328,6 +329,65 @@ describe("Interaction logics", () => {
             ).to.equal(true);
         });
 
+        it("downloads multiple files", async () => {
+            // Arrange
+            const state = mergeState(initialState, {
+                interaction: {
+                    platformDependentServices: {
+                        fileDownloadService: new FileDownloadServiceNoop(),
+                    },
+                },
+            });
+            const { store, logicMiddleware, actions } = configureMockStore({
+                state,
+                logics: interactionLogics,
+            });
+            const file1: FmsFile = {
+                file_id: "930213",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
+            const file2: FmsFile = {
+                file_id: "8932432",
+                file_name: "test_file_2",
+                file_size: 2349014,
+                file_path: "/some/path/test_file_2",
+                uploaded: "whenever",
+                annotations: [],
+            };
+
+            // Act
+            store.dispatch(downloadFiles([file1, file2]));
+            await logicMiddleware.whenComplete();
+
+            // Assert
+            expect(
+                actions.includesMatch({
+                    type: SET_STATUS,
+                    payload: {
+                        data: {
+                            status: ProcessStatus.STARTED,
+                            fileId: [file1.file_id],
+                        },
+                    },
+                })
+            ).to.be.true;
+            expect(
+                actions.includesMatch({
+                    type: SET_STATUS,
+                    payload: {
+                        data: {
+                            status: ProcessStatus.STARTED,
+                            fileId: [file2.file_id],
+                        },
+                    },
+                })
+            ).to.be.true;
+        });
+
         it("marks the success of a file download with a status update", async () => {
             // Arrange
             const state = mergeState(initialState, {
@@ -341,16 +401,17 @@ describe("Interaction logics", () => {
                 state,
                 logics: interactionLogics,
             });
+            const file: FmsFile = {
+                file_id: "32490241",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
 
             // Act
-            store.dispatch(
-                downloadFile({
-                    id: "abc123",
-                    name: "foo.ext",
-                    path: "/some/path/foo.ext",
-                    size: 5,
-                })
-            );
+            store.dispatch(downloadFiles([file]));
             await logicMiddleware.whenComplete();
 
             // Assert
@@ -399,16 +460,17 @@ describe("Interaction logics", () => {
                 state,
                 logics: interactionLogics,
             });
+            const file: FmsFile = {
+                file_id: "5483295",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
 
             // Act
-            store.dispatch(
-                downloadFile({
-                    id: "abc123",
-                    name: "foo.ext",
-                    path: "/some/path/foo.ext",
-                    size: 5,
-                })
-            );
+            store.dispatch(downloadFiles([file]));
             await logicMiddleware.whenComplete();
 
             // Assert
@@ -448,16 +510,17 @@ describe("Interaction logics", () => {
                 state,
                 logics: interactionLogics,
             });
+            const file: FmsFile = {
+                file_id: "872342",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
 
             // Act
-            store.dispatch(
-                downloadFile({
-                    id: "abc123",
-                    name: "foo.ext",
-                    path: "/some/path/foo.ext",
-                    size: 5,
-                })
-            );
+            store.dispatch(downloadFiles([file]));
             await logicMiddleware.whenComplete();
 
             // Assert
@@ -512,16 +575,17 @@ describe("Interaction logics", () => {
                 state,
                 logics: interactionLogics,
             });
+            const file: FmsFile = {
+                file_id: "930213",
+                file_name: "test_file_1",
+                file_size: 18,
+                file_path: "/some/path/test_file_1",
+                uploaded: "whenever",
+                annotations: [],
+            };
 
             // Act
-            store.dispatch(
-                downloadFile({
-                    id: "abc123",
-                    name: "foo.ext",
-                    path: "/some/path/foo.ext",
-                    size: 5,
-                })
-            );
+            store.dispatch(downloadFiles([file]));
             await logicMiddleware.whenComplete();
 
             // Assert


### PR DESCRIPTION
This adds a new "Download" option to the context menu present when you right-click a selection of files. In addition to this the download button in the file details is a bit more obvious and paired with an "Open" button (to hopefully encourage opening files through the app like this rather than downloading them). This was a UX request submitted as a user request, a pretty common bit of feedback we get that people can't find our download feature.

**Testing**
Tested manually and with some unit tests