### PR TITLE
[SWE-778] Add font-size control button

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -15,6 +15,7 @@
     --file-details-width: 20%;
     --margin: 12px;
     --transition-duration: 0.5s;
+    --smaller-font-size: small;
     /* AICS brand colors pulled from AICS style guide */
     --primary-brand-dark-blue: #003057;
     --primary-brand-purple: #827aa3;

--- a/packages/core/components/AnnotationHierarchy/AnnotationHierarchy.module.css
+++ b/packages/core/components/AnnotationHierarchy/AnnotationHierarchy.module.css
@@ -4,6 +4,10 @@
     flex-direction: column;
 }
 
+.small-font {
+    font-size: var(--smaller-font-size);
+}
+
 .title {
     color: var(--primary-brand-dark-blue); /* defined in App.module.css */
     margin: 0 0 0.25rem 0;

--- a/packages/core/components/AnnotationHierarchy/index.tsx
+++ b/packages/core/components/AnnotationHierarchy/index.tsx
@@ -8,6 +8,7 @@ import HierarchyListItem from "./HierarchyListItem";
 import * as annotationSelectors from "../AnnotationSidebar/selectors";
 
 import styles from "./AnnotationHierarchy.module.css";
+import { selection } from "../../state";
 
 export const DROPPABLE_ID = "HIERARCHY_LIST";
 
@@ -23,6 +24,7 @@ interface AnnotationHierarchyProps {
 export default function AnnotationHierarchy(props: AnnotationHierarchyProps) {
     const { className, highlightDropZone } = props;
     const annotationHierarchyListItems = useSelector(annotationSelectors.getHierarchyListItems);
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
 
     return (
         <div className={classNames(styles.root, className)} id={Tutorial.ANNOTATION_HIERARCHY_ID}>
@@ -31,7 +33,9 @@ export default function AnnotationHierarchy(props: AnnotationHierarchyProps) {
                 Files will be grouped by the following annotations
             </h6>
             <DnDList
-                className={styles.hierarchy}
+                className={classNames(styles.hierarchy, {
+                    [styles.smallFont]: shouldDisplaySmallFont,
+                })}
                 highlight={highlightDropZone}
                 id={DROPPABLE_ID}
                 items={annotationHierarchyListItems}

--- a/packages/core/components/AnnotationHierarchy/test/AnnotationHierarchy.test.tsx
+++ b/packages/core/components/AnnotationHierarchy/test/AnnotationHierarchy.test.tsx
@@ -1,0 +1,49 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { DragDropContext } from "react-beautiful-dnd";
+import { Provider } from "react-redux";
+
+import { initialState } from "../../../state";
+import { DND_LIST_CONTAINER_ID } from "../../DnDList/DnDList";
+import AnnotationHierarchy from "..";
+
+import styles from "../AnnotationHierarchy.module.css";
+
+describe("<AnnotationHierarchy />", () => {
+    describe("Dynamic styling", () => {
+        [true, false].forEach((shouldDisplaySmallFont) => {
+            it(`Has ${
+                shouldDisplaySmallFont ? "" : "no"
+            } small font style when shouldDisplaySmallFont is ${shouldDisplaySmallFont}`, () => {
+                // Arrange
+                const { store } = configureMockStore({
+                    state: mergeState(initialState, {
+                        selection: {
+                            shouldDisplaySmallFont,
+                        },
+                    }),
+                });
+
+                // Act
+                const { getByTestId } = render(
+                    <Provider store={store}>
+                        <DragDropContext
+                            onDragEnd={() => {
+                                /* noop */
+                            }}
+                        >
+                            <AnnotationHierarchy highlightDropZone />
+                        </DragDropContext>
+                    </Provider>
+                );
+
+                // Assert
+                expect(
+                    getByTestId(DND_LIST_CONTAINER_ID).classList.contains(styles.smallFont)
+                ).to.equal(shouldDisplaySmallFont);
+            });
+        });
+    });
+});

--- a/packages/core/components/AnnotationList/AnnotationList.module.css
+++ b/packages/core/components/AnnotationList/AnnotationList.module.css
@@ -4,6 +4,10 @@
     flex-direction: column;
 }
 
+.small-font {
+    font-size: var(--smaller-font-size);
+}
+
 .title {
     color: var(--primary-brand-dark-blue); /* defined in App.module.css */
     margin: 0 0 0.25rem 0;

--- a/packages/core/components/AnnotationList/index.tsx
+++ b/packages/core/components/AnnotationList/index.tsx
@@ -49,6 +49,7 @@ export default function AnnotationList(props: AnnotationListProps) {
     const annotationsLoading = useSelector(
         selection.selectors.getAvailableAnnotationsForHierarchyLoading
     );
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const annotationListItems = useSelector(annotationSelectors.getAnnotationListItems);
     const [searchValue, setSearchValue] = React.useState("");
 
@@ -114,7 +115,9 @@ export default function AnnotationList(props: AnnotationListProps) {
                     />
                 </div>
                 <DnDList
-                    className={styles.list}
+                    className={classNames(styles.list, {
+                        [styles.smallFont]: shouldDisplaySmallFont,
+                    })}
                     items={filteredListItems}
                     id={DROPPABLE_ID}
                     isDropDisabled={true}

--- a/packages/core/components/AnnotationList/test/AnnotationList.test.tsx
+++ b/packages/core/components/AnnotationList/test/AnnotationList.test.tsx
@@ -10,6 +10,9 @@ import Annotation from "../../../entity/Annotation";
 import { annotationsJson } from "../../../entity/Annotation/mocks";
 import FileFilter from "../../../entity/FileFilter";
 import { initialState, reducer, reduxLogics, selection } from "../../../state";
+import { DND_LIST_CONTAINER_ID } from "../../DnDList/DnDList";
+
+import styles from "../AnnotationList.module.css";
 
 describe("<AnnotationList />", () => {
     before(() => {
@@ -207,6 +210,41 @@ describe("<AnnotationList />", () => {
 
             // Assert
             expect(() => getByText("Filtered")).to.throw();
+        });
+    });
+
+    describe("Dynamic styling", () => {
+        [true, false].forEach((shouldDisplaySmallFont) => {
+            it(`Has ${
+                shouldDisplaySmallFont ? "" : "no"
+            } small font style when shouldDisplaySmallFont is ${shouldDisplaySmallFont}`, () => {
+                // Arrange
+                const { store } = configureMockStore({
+                    state: mergeState(initialState, {
+                        selection: {
+                            shouldDisplaySmallFont,
+                        },
+                    }),
+                });
+
+                // Act
+                const { getByTestId } = render(
+                    <Provider store={store}>
+                        <DragDropContext
+                            onDragEnd={() => {
+                                /* noop */
+                            }}
+                        >
+                            <AnnotationList />
+                        </DragDropContext>
+                    </Provider>
+                );
+
+                // Assert
+                expect(
+                    getByTestId(DND_LIST_CONTAINER_ID).classList.contains(styles.smallFont)
+                ).to.equal(shouldDisplaySmallFont);
+            });
         });
     });
 });

--- a/packages/core/components/DnDList/DnDList.tsx
+++ b/packages/core/components/DnDList/DnDList.tsx
@@ -6,6 +6,8 @@ import DnDListItem from "./DnDListItem";
 
 import styles from "./DnDList.module.css";
 
+export const DND_LIST_CONTAINER_ID = "dnd-list-container-id";
+
 export interface DnDItem {
     description: string;
     disabled?: boolean;
@@ -52,6 +54,7 @@ export default function DnDList(props: DnDListProps) {
                         },
                         props.className
                     )}
+                    data-testid={DND_LIST_CONTAINER_ID}
                 >
                     {items.reduce((accum, item, index) => {
                         const disabled = loading || item.disabled;

--- a/packages/core/components/FileDetails/FileAnnotationRow.module.css
+++ b/packages/core/components/FileDetails/FileAnnotationRow.module.css
@@ -21,6 +21,10 @@
     font-weight: 500;
 }
 
+.small-font {
+    font-size: var(--smaller-font-size);
+}
+
 .value {
     /* flex child */
     flex: 1 1 60%;

--- a/packages/core/components/FileDetails/FileAnnotationRow.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationRow.tsx
@@ -1,10 +1,10 @@
 import classNames from "classnames";
 import * as React from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import getContextMenuItems from "../ContextMenu/items";
 import Cell from "../../components/FileRow/Cell";
-import { interaction } from "../../state";
+import { interaction, selection } from "../../state";
 
 import styles from "./FileAnnotationRow.module.css";
 
@@ -20,6 +20,7 @@ interface FileAnnotationRowProps {
  */
 export default function FileAnnotationRow(props: FileAnnotationRowProps) {
     const dispatch = useDispatch();
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
 
     const onContextMenuHandlerFactory = (clipboardText: string) => {
         return (evt: React.MouseEvent) => {
@@ -39,7 +40,13 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
 
     return (
         <div className={classNames(props.className, styles.row)}>
-            <Cell className={classNames(styles.cell, styles.key)} columnKey="key" width={1}>
+            <Cell
+                className={classNames(styles.cell, styles.key, {
+                    [styles.smallFont]: shouldDisplaySmallFont,
+                })}
+                columnKey="key"
+                width={1}
+            >
                 <span
                     style={{ userSelect: "text" }}
                     onContextMenu={onContextMenuHandlerFactory(props.name)}
@@ -47,7 +54,13 @@ export default function FileAnnotationRow(props: FileAnnotationRowProps) {
                     {props.name}
                 </span>
             </Cell>
-            <Cell className={classNames(styles.cell, styles.value)} columnKey="value" width={1}>
+            <Cell
+                className={classNames(styles.cell, styles.value, {
+                    [styles.smallFont]: shouldDisplaySmallFont,
+                })}
+                columnKey="value"
+                width={1}
+            >
                 <span
                     style={{ userSelect: "text" }}
                     onContextMenu={onContextMenuHandlerFactory(props.value.trim())}

--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -108,6 +108,42 @@
     width: 100%;
 }
 
+.font-size-button-container {
+    display: flex;
+    height: min-content;
+}
+
+.font-size-button {
+    background-color: darkgrey;
+    border-radius: 0;
+    font-size: 10px;
+    font-weight: normal;
+    height: min-content;
+    padding: 0.25em;
+    width: min-content;
+}
+
+.font-size-button:hover:not(.disabled) {
+    background-color: #878787;
+    color: white;
+}
+
+.disabled {
+    cursor: default;
+}
+
+.font-size-button:first-child {
+    border-right: 1px solid black;
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    margin-left: auto;
+}
+
+.font-size-button:last-child {
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
+
 .annotation-list {
     padding: var(--padding);
 }

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -1,6 +1,7 @@
-import { IButtonStyles } from "@fluentui/react";
+import { ActionButton, IButtonStyles } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import FileThumbnail from "../../components/FileThumbnail";
 import WindowActionButton from "../../components/WindowActionButton";
@@ -11,6 +12,7 @@ import FileAnnotationList from "./FileAnnotationList";
 import OpenFileButton from "./OpenFileButton";
 import Pagination from "./Pagination";
 import { ROOT_ELEMENT_ID } from "../../App";
+import { selection } from "../../state";
 import SvgIcon from "../../components/SvgIcon";
 import { NO_IMAGE_ICON_PATH_DATA } from "../../icons";
 
@@ -121,8 +123,10 @@ function resizeHandleDoubleClick() {
  * Right-hand sidebar of application. Displays details of selected file(s).
  */
 export default function FileDetails(props: FileDetails) {
-    const [windowState, dispatch] = React.useReducer(windowStateReducer, INITIAL_STATE);
+    const globalDispatch = useDispatch();
+    const [windowState, windowDispatch] = React.useReducer(windowStateReducer, INITIAL_STATE);
     const [fileDetails, isLoading] = useFileDetails();
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
 
     // If FileDetails pane is minimized, set its width to the width of the WindowActionButtons. Else, let it be
     // defined by whatever the CSS determines (setting an inline style to undefined will prompt ReactDOM to not apply
@@ -211,7 +215,7 @@ export default function FileDetails(props: FileDetails) {
                                 <WindowActionButton
                                     key={action}
                                     action={action}
-                                    onClick={() => dispatch({ type: action })}
+                                    onClick={() => windowDispatch({ type: action })}
                                     width={WINDOW_ACTION_BUTTON_WIDTH}
                                 />
                             ))}
@@ -222,6 +226,32 @@ export default function FileDetails(props: FileDetails) {
                             [styles.hidden]: windowState.state === WindowState.MINIMIZED,
                         })}
                     />
+                    <div className={styles.fontSizeButtonContainer}>
+                        <ActionButton
+                            className={classNames(styles.fontSizeButton, {
+                                [styles.disabled]: shouldDisplaySmallFont,
+                            })}
+                            disabled={shouldDisplaySmallFont}
+                            onClick={() =>
+                                globalDispatch(
+                                    selection.actions.adjustGlobalFontSize(!shouldDisplaySmallFont)
+                                )
+                            }
+                            text="a"
+                        />
+                        <ActionButton
+                            className={classNames(styles.fontSizeButton, {
+                                [styles.disabled]: !shouldDisplaySmallFont,
+                            })}
+                            disabled={!shouldDisplaySmallFont}
+                            onClick={() =>
+                                globalDispatch(
+                                    selection.actions.adjustGlobalFontSize(!shouldDisplaySmallFont)
+                                )
+                            }
+                            text="A"
+                        />
+                    </div>
                     <div className={styles.contentContainer}>
                         <div
                             className={classNames(styles.overflowContainer, {

--- a/packages/core/components/FileDetails/test/FileAnnotationRow.test.tsx
+++ b/packages/core/components/FileDetails/test/FileAnnotationRow.test.tsx
@@ -1,0 +1,49 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+
+import { initialState } from "../../../state";
+import { NON_RESIZEABLE_CELL_TEST_ID } from "../../FileRow/Cell";
+import FileAnnotationRow from "../FileAnnotationRow";
+
+import styles from "../FileAnnotationRow.module.css";
+
+describe("<FileAnnotationRow />", () => {
+    describe("Dynamic styling", () => {
+        [true, false].forEach((shouldDisplaySmallFont) => {
+            it(`Has${
+                shouldDisplaySmallFont ? "" : " no"
+            } small font style when shouldDisplaySmallFont is ${shouldDisplaySmallFont}`, () => {
+                // Arrange
+                const annotationName = "test-annotation-name";
+                const annotationValue = "90123131";
+                const { store } = configureMockStore({
+                    state: mergeState(initialState, {
+                        selection: {
+                            shouldDisplaySmallFont,
+                        },
+                    }),
+                });
+
+                // Act
+                const { getAllByTestId } = render(
+                    <Provider store={store}>
+                        <FileAnnotationRow name={annotationName} value={annotationValue} />
+                    </Provider>
+                );
+
+                // Assert
+                const cells = getAllByTestId(NON_RESIZEABLE_CELL_TEST_ID);
+                expect(cells).to.be.lengthOf(2);
+                expect(cells[0].classList.contains(styles.smallFont)).to.equal(
+                    shouldDisplaySmallFont
+                );
+                expect(cells[1].classList.contains(styles.smallFont)).to.equal(
+                    shouldDisplaySmallFont
+                );
+            });
+        });
+    });
+});

--- a/packages/core/components/FileList/LazilyRenderedRow.module.css
+++ b/packages/core/components/FileList/LazilyRenderedRow.module.css
@@ -12,3 +12,7 @@
     margin: 0;
     border: var(--margin) solid #669bf4;
 }
+
+.small-font {
+    font-size: var(--smaller-font-size);
+}

--- a/packages/core/components/FileList/LazilyRenderedRow.tsx
+++ b/packages/core/components/FileList/LazilyRenderedRow.tsx
@@ -38,6 +38,7 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
         style,
     } = props;
 
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
     const annotations = useSelector(selection.selectors.getOrderedDisplayAnnotations);
     const columnWidths = useSelector(selection.selectors.getColumnWidths);
     const fileSelection = useSelector(selection.selectors.getFileSelection);
@@ -62,6 +63,9 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
         content = (
             <FileRow
                 cells={cells}
+                cellClassName={classNames({
+                    [styles.smallFont]: shouldDisplaySmallFont,
+                })}
                 className={classNames(styles.row, {
                     [styles.selected]: isSelected,
                     [styles.focused]: isFocused,
@@ -76,6 +80,9 @@ export default function LazilyRenderedRow(props: LazilyRenderedRowProps) {
 
     return (
         <div
+            className={classNames({
+                [styles.smallFont]: shouldDisplaySmallFont,
+            })}
             style={{
                 ...style,
                 width: `calc(100% - ${2 * MARGIN}px)`,

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -33,7 +33,6 @@ interface FileListProps {
 
 const DEFAULTS = {
     totalCount: DEFAULT_TOTAL_COUNT,
-    rowHeight: 22,
 };
 
 const MAX_NON_ROOT_HEIGHT = 300;
@@ -43,12 +42,14 @@ const MAX_NON_ROOT_HEIGHT = 300;
  * itself out to be 100% the height and width of its parent.
  */
 export default function FileList(props: FileListProps) {
-    const { className, fileSet, isRoot, rowHeight, sortOrder } = defaults({}, props, DEFAULTS);
-
     const [totalCount, setTotalCount] = React.useState<number | null>(null);
+    const fileSelection = useSelector(selection.selectors.getFileSelection);
+    const isDisplayingSmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
+    const { className, fileSet, isRoot, rowHeight, sortOrder } = defaults({}, props, DEFAULTS, {
+        rowHeight: isDisplayingSmallFont ? 18 : 22,
+    });
 
     const onSelect = useFileSelector(fileSet, sortOrder);
-    const fileSelection = useSelector(selection.selectors.getFileSelection);
 
     // Callback provided to individual LazilyRenderedRows to be called on `contextmenu`
     const onFileRowContextMenu = useFileAccessContextMenu();

--- a/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedRow.test.tsx
@@ -10,6 +10,8 @@ import LazilyRenderedRow from "../LazilyRenderedRow";
 import { initialState } from "../../../state";
 import FileSet from "../../../entity/FileSet";
 
+import styles from "../LazilyRenderedRow.module.css";
+
 describe("<LazilyRenderedRow />", () => {
     const fileNameAnnotation = new Annotation({
         annotationDisplayName: "Name",
@@ -87,5 +89,34 @@ describe("<LazilyRenderedRow />", () => {
         // Assert
         expect(queryByText("my_image.czi")).to.equal(null);
         expect(queryByText("Loading...")).to.not.equal(null);
+    });
+
+    describe("Dynamic styling", () => {
+        [true, false].forEach((shouldDisplaySmallFont) => {
+            it(`Has${
+                shouldDisplaySmallFont ? "" : " no"
+            } small font style when shouldDisplaySmallFont is ${shouldDisplaySmallFont}`, () => {
+                // Arrange
+                const { store } = configureMockStore({
+                    state: mergeState(initialState, {
+                        selection: {
+                            shouldDisplaySmallFont,
+                        },
+                    }),
+                });
+
+                // Act
+                const { getByText } = render(
+                    <Provider store={store}>
+                        <LazilyRenderedRow data={makeItemData()} index={23} style={{}} />
+                    </Provider>
+                );
+
+                // Assert
+                expect(getByText("Loading...").classList.contains(styles.smallFont)).to.equal(
+                    shouldDisplaySmallFont
+                );
+            });
+        });
     });
 });

--- a/packages/core/components/FileRow/Cell.tsx
+++ b/packages/core/components/FileRow/Cell.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 
 import styles from "./Cell.module.css";
 
+export const NON_RESIZEABLE_CELL_TEST_ID = "non-resizeable-cell-test-id";
+
 export interface CellProps {
     className?: string;
     columnKey: string;
@@ -118,6 +120,7 @@ export default class Cell extends React.Component<React.PropsWithChildren<CellPr
                 className={classNames(styles.cell, this.props.className)}
                 onContextMenu={this.props.onContextMenu}
                 style={{ width: `${this.props.width * 100}%` }}
+                data-testid={NON_RESIZEABLE_CELL_TEST_ID}
             >
                 {this.props.children}
             </div>

--- a/packages/core/components/FileRow/index.tsx
+++ b/packages/core/components/FileRow/index.tsx
@@ -16,6 +16,7 @@ export interface CellConfig {
 interface FileRowProps {
     cells: CellConfig[];
     className?: string;
+    cellClassName?: string;
     rowIdentifier?: any;
     onContextMenu?: (evt: React.MouseEvent) => void;
     onResize?: (columnKey: string, nextWidth?: number) => void;
@@ -46,6 +47,7 @@ export default function FileRow(props: FileRowProps) {
         <div className={classNames(styles.row, className)} onClick={onClick}>
             {map(cells, (cell) => (
                 <Cell
+                    className={props.cellClassName}
                     key={cell.columnKey}
                     columnKey={cell.columnKey}
                     onContextMenu={onContextMenu}

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -523,3 +523,22 @@ export function selectTutorial(tutorial?: Tutorial): SelectTutorial {
         type: SELECT_TUTORIAL,
     };
 }
+
+/**
+ * ADJUST_GLOBAL_FONT_SIZE
+ *
+ * Intention to set whether the current font size should be small or the default
+ */
+export const ADJUST_GLOBAL_FONT_SIZE = makeConstant(STATE_BRANCH_NAME, "adjust-global-font-size");
+
+export interface AdjustGlobalFontSize {
+    payload: boolean;
+    type: string;
+}
+
+export function adjustGlobalFontSize(shouldDisplaySmallFont: boolean): AdjustGlobalFontSize {
+    return {
+        payload: shouldDisplaySmallFont,
+        type: ADJUST_GLOBAL_FONT_SIZE,
+    };
+}

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -23,6 +23,7 @@ import {
     CHANGE_COLLECTION,
     CHANGE_VIEW,
     SELECT_TUTORIAL,
+    ADJUST_GLOBAL_FONT_SIZE,
 } from "./actions";
 import FileSort, { SortOrder } from "../../entity/FileSort";
 import Tutorial from "../../entity/Tutorial";
@@ -40,6 +41,7 @@ export interface SelectionStateBranch {
     fileSelection: FileSelection;
     filters: FileFilter[];
     openFileFolders: FileFolder[];
+    shouldDisplaySmallFont: boolean;
     sortColumn?: FileSort;
     tutorial?: Tutorial;
 }
@@ -58,6 +60,7 @@ export const initialState = {
     fileSelection: new FileSelection(),
     filters: [],
     openFileFolders: [],
+    shouldDisplaySmallFont: false,
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 
@@ -66,6 +69,10 @@ export default makeReducer<SelectionStateBranch>(
         [SELECT_TUTORIAL]: (state, action) => ({
             ...state,
             tutorial: action.payload,
+        }),
+        [ADJUST_GLOBAL_FONT_SIZE]: (state, action) => ({
+            ...state,
+            shouldDisplaySmallFont: action.payload,
         }),
         [SET_FILE_FILTERS]: (state, action) => ({
             ...state,

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -21,6 +21,7 @@ export const getFileFilters = (state: State) => state.selection.filters;
 export const getCollection = (state: State) => state.selection.collection;
 export const getFileSelection = (state: State) => state.selection.fileSelection;
 export const getOpenFileFolders = (state: State) => state.selection.openFileFolders;
+export const getShouldDisplaySmallFont = (state: State) => state.selection.shouldDisplaySmallFont;
 export const getSortColumn = (state: State) => state.selection.sortColumn;
 export const getTutorial = (state: State) => state.selection.tutorial;
 


### PR DESCRIPTION
This adds a small font size control toggle for users that wish to have the font-size small to view more data at once.

Bigger font
<img width="760" alt="Screen Shot 2023-03-09 at 9 14 51 AM" src="https://user-images.githubusercontent.com/41307451/224105620-08e65e38-e97f-45ce-ba25-a8ac7e2e8ab1.png">

Smaller font
<img width="758" alt="Screen Shot 2023-03-09 at 9 14 56 AM" src="https://user-images.githubusercontent.com/41307451/224105655-d224844d-901d-4b5b-87c0-3d074215f770.png">
