### PR TITLE
Feature/allow annotation interactions while loading

### DIFF
--- a/dev-docs/02-setup-and-workflow.md
+++ b/dev-docs/02-setup-and-workflow.md
@@ -41,6 +41,12 @@ rendered application, like `desktop` or `web`.
 To make that happen:
 1. Navigate to either `packages/desktop` or `packages/web` and run `npm run start`.
 
+### Testing
+Most components in the project have associated unit tests; to run the full suite, run `npm run test`.
+The unit tests for each of the packages can also be run independently, using `npm run test:core`, `npm run test:desktop`, 
+or `npm run test:web`, respectively.
+
+To run the linter, use `npm run lint`, and for typechecking, use `npm run typeCheck`.
 
 ### Adding a dependency to to either the `desktop` or `web` subpackages
 In the case that you need to add either a dependency or devDependency to either the `desktop` or `web` subpackages within this

--- a/packages/core/components/AnnotationList/AnnotationListItem.tsx
+++ b/packages/core/components/AnnotationList/AnnotationListItem.tsx
@@ -49,7 +49,7 @@ export default React.memo(function AnnotationListItem(props: AnnotationListItemP
                 data-testid="annotation-list-item"
                 className={classNames(
                     {
-                        [styles.disabled]: disabled || loading,
+                        [styles.disabled]: disabled,
                     },
                     styles.title
                 )}

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -10,6 +10,7 @@ import Tutorial from "../../entity/Tutorial";
 import RootLoadingIndicator from "./RootLoadingIndicator";
 import useDirectoryHierarchy from "./useDirectoryHierarchy";
 import FileMetadataSearchBar from "../FileMetadataSearchBar";
+import EmptyFileListMessage from "../EmptyFileListMessage";
 
 import styles from "./DirectoryTree.module.css";
 
@@ -84,6 +85,9 @@ export default function DirectoryTree(props: FileListProps) {
                 aria-multiselectable="true"
                 id={Tutorial.FILE_LIST_ID}
             >
+                {!error && (!content || (Array.isArray(content) && !content.length)) && (
+                    <EmptyFileListMessage />
+                )}
                 {!error && content}
                 {error && (
                     <aside className={styles.errorMessage}>

--- a/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
+++ b/packages/core/components/DirectoryTree/test/DirectoryTree.test.tsx
@@ -474,4 +474,30 @@ describe("<DirectoryTree />", () => {
         header = await findByTestId(directoryTreeNodes[0], "treeitemheader"); // refresh node
         expect(header.classList.contains(styles.focused)).to.be.true;
     });
+
+    it("displays 'No files found' when no files found", async () => {
+        sandbox.restore();
+        const emptyFileService = new FileService();
+        sandbox.stub(interaction.selectors, "getFileService").returns(emptyFileService);
+
+        const { store } = configureMockStore({
+            state,
+            responseStubs,
+            reducer,
+            logics: reduxLogics,
+        });
+
+        const { queryAllByRole, findByText } = render(
+            <Provider store={store}>
+                <DirectoryTree />
+            </Provider>
+        );
+
+        // No tree items should load
+        const directoryTreeNodes = queryAllByRole("treeitem");
+        expect(directoryTreeNodes.length).to.equal(0);
+
+        // Wait for the fileService call to return, then check for empty list message
+        await findByText("Sorry! No files found");
+    });
 });

--- a/packages/core/components/DnDList/DnDList.tsx
+++ b/packages/core/components/DnDList/DnDList.tsx
@@ -57,7 +57,7 @@ export default function DnDList(props: DnDListProps) {
                     data-testid={DND_LIST_CONTAINER_ID}
                 >
                     {items.reduce((accum, item, index) => {
-                        const disabled = loading || item.disabled;
+                        const disabled = item.disabled;
                         return [
                             ...accum,
                             ...(dividers && dividers[index] ? [dividers[index]] : []),

--- a/packages/core/components/EmptyFileListMessage/EmptyFileListMessage.module.css
+++ b/packages/core/components/EmptyFileListMessage/EmptyFileListMessage.module.css
@@ -1,0 +1,13 @@
+.empty-file-list-container {
+    display: flex;
+    height: 100%;
+}
+
+.empty-file-list-message {
+    margin: auto;
+    text-align: center;
+}
+
+.empty-search-icon {
+    font-size: 7em;
+}

--- a/packages/core/components/EmptyFileListMessage/index.tsx
+++ b/packages/core/components/EmptyFileListMessage/index.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import styles from "./EmptyFileListMessage.module.css";
+import { Icon } from "@fluentui/react";
+
+export default function EmptyFileListMessage() {
+    return (
+        <div className={styles.emptyFileListContainer}>
+            <div className={styles.emptyFileListMessage}>
+                <Icon className={styles.emptySearchIcon} iconName="SearchIssue" />
+                <h2>Sorry! No files found</h2>
+                <h3>
+                    Double check your filters for any issues and then contact the software team if
+                    you still expect there to be matches present.
+                </h3>
+            </div>
+        </div>
+    );
+}

--- a/packages/core/components/FileList/FileList.module.css
+++ b/packages/core/components/FileList/FileList.module.css
@@ -8,20 +8,6 @@
     height: 100%;
 }
 
-.empty-file-list-container {
-    display: flex;
-    height: 100%;
-}
-
-.empty-file-list-message {
-    margin: auto;
-    text-align: center;
-}
-
-.empty-search-icon {
-    font-size: 7em;
-}
-
 .list {
     height: calc(100% - var(--row-count-height));
 }

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -1,4 +1,3 @@
-import { Icon } from "@fluentui/react";
 import classNames from "classnames";
 import debouncePromise from "debounce-promise";
 import { defaults, isFunction } from "lodash";
@@ -14,6 +13,7 @@ import { selection } from "../../state";
 import useLayoutMeasurements from "../../hooks/useLayoutMeasurements";
 import useFileSelector from "./useFileSelector";
 import useFileAccessContextMenu from "./useFileAccessContextMenu";
+import EmptyFileListMessage from "../EmptyFileListMessage";
 
 import styles from "./FileList.module.css";
 
@@ -160,18 +160,7 @@ export default function FileList(props: FileListProps) {
             );
         }
     } else {
-        content = (
-            <div className={styles.emptyFileListContainer}>
-                <div className={styles.emptyFileListMessage}>
-                    <Icon className={styles.emptySearchIcon} iconName="SearchIssue" />
-                    <h2>Sorry! No files found :(</h2>
-                    <h3>
-                        Double check your filters for any issues and then contact the Software team
-                        if you still expect there to be matches present.
-                    </h3>
-                </div>
-            </div>
-        );
+        content = <EmptyFileListMessage />;
     }
 
     return (

--- a/packages/core/components/FileList/test/FileList.test.tsx
+++ b/packages/core/components/FileList/test/FileList.test.tsx
@@ -53,7 +53,7 @@ describe("<FileList />", () => {
         expect(queryByText("Counting files...")).to.exist;
 
         // Wait for the fileService call to return, then check for updated list length display
-        await findByText("Sorry! No files found :(");
+        await findByText("Sorry! No files found");
 
         // Assert
         expect(queryByText("Counting files...")).to.not.exist;


### PR DESCRIPTION
### Description
This allows users to continue to interact with annotations in the 'Available Annotations' list while they are loading. 
- Removed `disabled` styling for loading items
- Separated the 'no files found' message and its styles from the `FileList` component so that it can be re-used for the `DirectoryTree`
- Added a short description of how to run tests in the dev-docs
- Realized I didn't port over the `:(` so removed it from the unit test, can definitely add it back in

### Testing
Tested manually on local build, on site and off site (with VPN)


closes #51 