### PR TITLE
Feature/default to past year filter

### DIFF
--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -38,17 +38,16 @@ const DATE_LAST_MONTH = new Date(BEGINNING_OF_TODAY);
 DATE_LAST_MONTH.setMonth(BEGINNING_OF_TODAY.getMonth() - 1);
 const DATE_LAST_WEEK = new Date(BEGINNING_OF_TODAY);
 DATE_LAST_WEEK.setDate(BEGINNING_OF_TODAY.getDate() - 7);
+export const PAST_YEAR_FILTER = new FileFilter(
+    AnnotationName.UPLOADED,
+    `RANGE(${DATE_LAST_YEAR.toISOString()},${END_OF_TODAY.toISOString()})`
+);
 export const RELATIVE_DATE_RANGES = [
     {
         name: "Uploaded in last year",
         description:
             "This will automatically filter files down to those uploaded within the last year",
-        filters: [
-            new FileFilter(
-                AnnotationName.UPLOADED,
-                `RANGE(${DATE_LAST_YEAR.toISOString()},${END_OF_TODAY.toISOString()})`
-            ),
-        ],
+        filters: [PAST_YEAR_FILTER],
         hierarchy: undefined,
         sort: undefined,
     },
@@ -105,12 +104,6 @@ export const RELATIVE_DATE_RANGES = [
         hierarchy: undefined,
         sort: undefined,
     },
-];
-export const INITIAL_DATE_FILTER = [
-    new FileFilter(
-        AnnotationName.UPLOADED,
-        `RANGE(${DATE_LAST_YEAR.toISOString()},${END_OF_TODAY.toISOString()})`
-    ),
 ];
 
 export const TOP_LEVEL_FILE_ANNOTATIONS = [

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -106,6 +106,12 @@ export const RELATIVE_DATE_RANGES = [
         sort: undefined,
     },
 ];
+export const INITIAL_DATE_FILTER = [
+    new FileFilter(
+        AnnotationName.UPLOADED,
+        `RANGE(${DATE_LAST_YEAR.toISOString()},${END_OF_TODAY.toISOString()})`
+    ),
+];
 
 export const TOP_LEVEL_FILE_ANNOTATIONS = [
     new Annotation({

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -2,7 +2,7 @@ import { makeReducer } from "@aics/redux-utils";
 import { castArray, difference, omit, without } from "lodash";
 
 import interaction from "../interaction";
-import { AnnotationName, RELATIVE_DATE_RANGES } from "../../constants";
+import { AnnotationName, INITIAL_DATE_FILTER } from "../../constants";
 import Annotation from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
@@ -46,10 +46,6 @@ export interface SelectionStateBranch {
     tutorial?: Tutorial;
 }
 
-const initialDateFilter = RELATIVE_DATE_RANGES.filter((relativeDateRange) =>
-    relativeDateRange.name.toLowerCase().includes("last year")
-)[0].filters;
-
 export const initialState = {
     annotationHierarchy: [],
     availableAnnotationsForHierarchy: [],
@@ -62,7 +58,7 @@ export const initialState = {
     },
     displayAnnotations: [],
     fileSelection: new FileSelection(),
-    filters: [...initialDateFilter],
+    filters: [...INITIAL_DATE_FILTER],
     openFileFolders: [],
     shouldDisplaySmallFont: false,
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -2,7 +2,7 @@ import { makeReducer } from "@aics/redux-utils";
 import { castArray, difference, omit, without } from "lodash";
 
 import interaction from "../interaction";
-import { AnnotationName } from "../../constants";
+import { AnnotationName, RELATIVE_DATE_RANGES } from "../../constants";
 import Annotation from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
@@ -46,6 +46,10 @@ export interface SelectionStateBranch {
     tutorial?: Tutorial;
 }
 
+const initialDateFilter = RELATIVE_DATE_RANGES.filter((relativeDateRange) =>
+    relativeDateRange.name.toLowerCase().includes("last year")
+)[0].filters;
+
 export const initialState = {
     annotationHierarchy: [],
     availableAnnotationsForHierarchy: [],
@@ -58,7 +62,7 @@ export const initialState = {
     },
     displayAnnotations: [],
     fileSelection: new FileSelection(),
-    filters: [],
+    filters: [...initialDateFilter],
     openFileFolders: [],
     shouldDisplaySmallFont: false,
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -2,7 +2,7 @@ import { makeReducer } from "@aics/redux-utils";
 import { castArray, difference, omit, without } from "lodash";
 
 import interaction from "../interaction";
-import { AnnotationName, INITIAL_DATE_FILTER } from "../../constants";
+import { AnnotationName, PAST_YEAR_FILTER } from "../../constants";
 import Annotation from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
@@ -58,7 +58,7 @@ export const initialState = {
     },
     displayAnnotations: [],
     fileSelection: new FileSelection(),
-    filters: [...INITIAL_DATE_FILTER],
+    filters: [PAST_YEAR_FILTER],
     openFileFolders: [],
     shouldDisplaySmallFont: false,
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),

--- a/packages/core/state/selection/test/logics.test.ts
+++ b/packages/core/state/selection/test/logics.test.ts
@@ -794,6 +794,7 @@ describe("Selection logics", () => {
                 logics: selectionLogics,
                 state: initialState,
             });
+            const currentFilters = initialState.selection.filters;
 
             // act
             const filter = new FileFilter("foo", 2);
@@ -804,7 +805,7 @@ describe("Selection logics", () => {
             expect(
                 actions.includes({
                     type: SET_FILE_FILTERS,
-                    payload: [filter],
+                    payload: [filter, ...currentFilters],
                 })
             ).to.equal(true);
         });


### PR DESCRIPTION
### Description
This reduces query time for the initial load by defaulting to a one year filter on first open. 

### Testing
Tested manually on local build, on site and off site (with VPN). Also updated unit tests 

closes #52 