### PR TITLE
Feature/create thumbnail view

### DIFF
--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -114,7 +114,7 @@
 }
 
 .font-size-button {
-    background-color: darkgrey;
+    background-color: lightgrey;
     border-radius: 0;
     font-size: 10px;
     font-weight: normal;

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -252,7 +252,6 @@ export default function FileDetails(props: FileDetails) {
                     >
                         <Icon iconName="GridViewMedium"></Icon>
                     </ActionButton>
-
                     <ActionButton
                         className={classNames(styles.fontSizeButton, {
                             [styles.disabled]:

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -1,4 +1,4 @@
-import { ActionButton, IButtonStyles } from "@fluentui/react";
+import { ActionButton, IButtonStyles, Icon } from "@fluentui/react";
 import classNames from "classnames";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -15,6 +15,7 @@ import { ROOT_ELEMENT_ID } from "../../App";
 import { selection } from "../../state";
 import SvgIcon from "../../components/SvgIcon";
 import { NO_IMAGE_ICON_PATH_DATA } from "../../icons";
+import { RENDERABLE_IMAGE_FORMATS, THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
 
 import styles from "./FileDetails.module.css";
 
@@ -126,7 +127,11 @@ export default function FileDetails(props: FileDetails) {
     const globalDispatch = useDispatch();
     const [windowState, windowDispatch] = React.useReducer(windowStateReducer, INITIAL_STATE);
     const [fileDetails, isLoading] = useFileDetails();
+    const fileGridColumnCount = useSelector(selection.selectors.getFileGridColumnCount);
     const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
+    const shouldDisplayThumbnailView = useSelector(
+        selection.selectors.getShouldDisplayThumbnailView
+    );
 
     // If FileDetails pane is minimized, set its width to the width of the WindowActionButtons. Else, let it be
     // defined by whatever the CSS determines (setting an inline style to undefined will prompt ReactDOM to not apply
@@ -164,8 +169,7 @@ export default function FileDetails(props: FileDetails) {
             </div>
         );
     } else if (fileDetails) {
-        const renderableImageFormats = [".jpg", ".jpeg", ".png", ".gif"];
-        const isFileRenderableImage = renderableImageFormats.some((format) =>
+        const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
             fileDetails?.name.toLowerCase().endsWith(format)
         );
         if (isFileRenderableImage) {
@@ -226,6 +230,65 @@ export default function FileDetails(props: FileDetails) {
                             [styles.hidden]: windowState.state === WindowState.MINIMIZED,
                         })}
                     />
+                    <ActionButton
+                        className={classNames(styles.fontSizeButton, {
+                            [styles.disabled]:
+                                shouldDisplayThumbnailView &&
+                                fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE,
+                        })}
+                        disabled={
+                            shouldDisplayThumbnailView &&
+                            fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE
+                        }
+                        onClick={() => {
+                            globalDispatch(selection.actions.setFileThumbnailView(true));
+                            globalDispatch(
+                                selection.actions.setFileGridColumnCount(
+                                    THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE
+                                )
+                            );
+                        }}
+                        title="Large thumbnail view"
+                    >
+                        <Icon iconName="GridViewMedium"></Icon>
+                    </ActionButton>
+
+                    <ActionButton
+                        className={classNames(styles.fontSizeButton, {
+                            [styles.disabled]:
+                                shouldDisplayThumbnailView &&
+                                fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL,
+                        })}
+                        disabled={
+                            shouldDisplayThumbnailView &&
+                            fileGridColumnCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL
+                        }
+                        onClick={() => {
+                            globalDispatch(selection.actions.setFileThumbnailView(true));
+                            globalDispatch(
+                                selection.actions.setFileGridColumnCount(
+                                    THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL
+                                )
+                            );
+                        }}
+                        title="Small thumbnail view"
+                    >
+                        <Icon iconName="GridViewSmall"></Icon>
+                    </ActionButton>
+                    <ActionButton
+                        className={classNames(styles.fontSizeButton, {
+                            [styles.disabled]: !shouldDisplayThumbnailView,
+                        })}
+                        disabled={!shouldDisplayThumbnailView}
+                        onClick={() =>
+                            globalDispatch(
+                                selection.actions.setFileThumbnailView(!shouldDisplayThumbnailView)
+                            )
+                        }
+                        title="List view"
+                    >
+                        <Icon iconName="BulletedList"></Icon>
+                    </ActionButton>
                     <div className={styles.fontSizeButtonContainer}>
                         <ActionButton
                             className={classNames(styles.fontSizeButton, {

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.module.css
@@ -1,0 +1,25 @@
+.small-font {
+  font-size: var(--smaller-font-size);
+}
+
+.file-label {
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+
+.thumbnail-wrapper {
+  padding: 10px
+}
+
+.no-thumbnail {
+  fill: var(--grey);
+}
+
+.selected {
+  background-color: #d4e3fc;
+}
+
+.focused {
+  margin: 0;
+  border: 2px solid #669bf4;
+}

--- a/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
+++ b/packages/core/components/FileList/LazilyRenderedThumbnail.tsx
@@ -1,0 +1,173 @@
+import classNames from "classnames";
+import * as React from "react";
+import { useSelector } from "react-redux";
+
+import FileSet from "../../entity/FileSet";
+import FileThumbnail from "../../components/FileThumbnail";
+import SvgIcon from "../../components/SvgIcon";
+import { selection } from "../../state";
+import { OnSelect } from "./useFileSelector";
+import { RENDERABLE_IMAGE_FORMATS, THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
+import { NO_IMAGE_ICON_PATH_DATA } from "../../icons";
+
+import styles from "./LazilyRenderedThumbnail.module.css";
+
+/**
+ * Contextual data passed to LazilyRenderedThumbnails by react-window. Basically a light-weight React context.
+ * The same data is passed to each LazilyRenderedThumbnail within the same FileGrid.
+ * Follows the pattern set by LazilyRenderedRow
+ */
+export interface LazilyRenderedThumbnailContext {
+    fileSet: FileSet;
+    itemCount: number;
+    measuredWidth: number;
+    onContextMenu: (evt: React.MouseEvent) => void;
+    onSelect: OnSelect;
+}
+
+interface LazilyRenderedThumbnailProps {
+    columnIndex: number; // injected by react-window
+    data: LazilyRenderedThumbnailContext; // injected by react-window
+    rowIndex: number; // injected by react-window
+    style: React.CSSProperties; // injected by react-window
+}
+
+const MARGIN = 20; // px;
+
+/**
+ * A single file in the listing of available files FMS.
+ * Follows the pattern set by LazilyRenderedRow
+ */
+export default function LazilyRenderedThumbnail(props: LazilyRenderedThumbnailProps) {
+    const {
+        data: { fileSet, itemCount, measuredWidth, onContextMenu, onSelect },
+        columnIndex,
+        rowIndex,
+        style,
+    } = props;
+
+    const shouldDisplaySmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
+    const fileSelection = useSelector(selection.selectors.getFileSelection);
+    const fileGridColCount = useSelector(selection.selectors.getFileGridColumnCount);
+    const overallIndex = fileGridColCount * rowIndex + columnIndex;
+    const file = fileSet.getFileByIndex(overallIndex);
+    const thumbnailSize = measuredWidth / fileGridColCount - 2 * MARGIN;
+
+    const isSelected = React.useMemo(() => {
+        return fileSelection.isSelected(fileSet, overallIndex);
+    }, [fileSelection, fileSet, overallIndex]);
+
+    const isFocused = React.useMemo(() => {
+        return fileSelection.isFocused(fileSet, overallIndex);
+    }, [fileSelection, fileSet, overallIndex]);
+
+    const onClick = (evt: React.MouseEvent) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+
+        if (onSelect && file !== undefined) {
+            onSelect(
+                { index: overallIndex, id: file.file_id },
+                {
+                    // Details on different OS keybindings
+                    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#Properties
+                    ctrlKeyIsPressed: evt.ctrlKey || evt.metaKey,
+                    shiftKeyIsPressed: evt.shiftKey,
+                }
+            );
+        }
+    };
+
+    // Display the start of the file name and at least part of the file type
+    const clipFileName = (filename: string) => {
+        if (fileGridColCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL && filename.length > 15) {
+            return filename.slice(0, 6) + "..." + filename.slice(-4);
+        } else if (filename.length > 20) {
+            return filename.slice(0, 9) + "..." + filename.slice(-8);
+        }
+        return filename;
+    };
+
+    // If the file has a thumbnail image specified, we want to display the specified thumbnail.
+    // Otherwise, we want to display the file itself as the thumbnail if possible.
+    // If there is no thumbnail and the file cannot be displayed as the thumbnail, show a no image icon
+    // TODO: Add custom icons per file type
+    let thumbnail = (
+        <SvgIcon
+            height={thumbnailSize}
+            pathData={NO_IMAGE_ICON_PATH_DATA}
+            viewBox="0,1,22,22"
+            width={thumbnailSize}
+            className={classNames(styles.noThumbnail)}
+        />
+    );
+    if (file?.thumbnail) {
+        // thumbnail exists
+        thumbnail = (
+            <div
+                className={classNames(styles.thumbnail)}
+                style={{ height: thumbnailSize, maxWidth: thumbnailSize }}
+            >
+                <FileThumbnail
+                    uri={`http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${file.thumbnail}`}
+                />
+            </div>
+        );
+    } else if (file) {
+        const isFileRenderableImage = RENDERABLE_IMAGE_FORMATS.some((format) =>
+            file?.file_name.toLowerCase().endsWith(format)
+        );
+        if (isFileRenderableImage) {
+            // render the image as the thumbnail
+            thumbnail = (
+                <div
+                    className={classNames(styles.fileThumbnailContainer, styles.thumbnail)}
+                    style={{ height: thumbnailSize, maxWidth: thumbnailSize }}
+                >
+                    <FileThumbnail
+                        uri={`http://aics.corp.alleninstitute.org/labkey/fmsfiles/image${file.file_path}`}
+                    />
+                </div>
+            );
+        }
+    }
+
+    let content;
+    if (file) {
+        const filenameForRender = clipFileName(file?.file_name);
+        content = (
+            <div
+                onClick={onClick}
+                className={classNames({
+                    [styles.selected]: isSelected,
+                    [styles.focused]: isFocused,
+                })}
+                title={file?.file_name}
+            >
+                {thumbnail}
+                <div
+                    className={classNames(styles.fileLabel, {
+                        [styles.smallFont]:
+                            shouldDisplaySmallFont ||
+                            fileGridColCount === THUMBNAIL_SIZE_TO_NUM_COLUMNS.SMALL,
+                    })}
+                >
+                    {filenameForRender}
+                </div>
+            </div>
+        );
+    } else if (overallIndex < itemCount) {
+        // Grid will attempt to render a cell even if we're past the total index
+        content = "Loading...";
+    } // No `else` since if past total index we stil want empty content to fill up the outer grid
+
+    return (
+        <div
+            className={classNames(styles.thumbnailWrapper)}
+            style={style}
+            onContextMenu={onContextMenu}
+        >
+            {content}
+        </div>
+    );
+}

--- a/packages/core/components/FileList/index.tsx
+++ b/packages/core/components/FileList/index.tsx
@@ -3,12 +3,13 @@ import debouncePromise from "debounce-promise";
 import { defaults, isFunction } from "lodash";
 import * as React from "react";
 import { useSelector } from "react-redux";
-import { FixedSizeList } from "react-window";
+import { FixedSizeGrid, FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
 import FileSet from "../../entity/FileSet";
 import Header from "./Header";
 import LazilyRenderedRow from "./LazilyRenderedRow";
+import LazilyRenderedThumbnail from "./LazilyRenderedThumbnail";
 import { selection } from "../../state";
 import useLayoutMeasurements from "../../hooks/useLayoutMeasurements";
 import useFileSelector from "./useFileSelector";
@@ -36,6 +37,8 @@ const DEFAULTS = {
 };
 
 const MAX_NON_ROOT_HEIGHT = 300;
+const SMALL_ROW_HEIGHT = 18;
+const TALL_ROW_HEIGHT = 22;
 
 /**
  * Wrapper for react-window-infinite-loader and react-window that knows how to lazily fetch its own data. It will lay
@@ -45,8 +48,17 @@ export default function FileList(props: FileListProps) {
     const [totalCount, setTotalCount] = React.useState<number | null>(null);
     const fileSelection = useSelector(selection.selectors.getFileSelection);
     const isDisplayingSmallFont = useSelector(selection.selectors.getShouldDisplaySmallFont);
+    const shouldDisplayThumbnailView = useSelector(
+        selection.selectors.getShouldDisplayThumbnailView
+    );
+    const fileGridColumnCount = useSelector(selection.selectors.getFileGridColumnCount);
+    const [measuredNodeRef, measuredHeight, measuredWidth] = useLayoutMeasurements<
+        HTMLDivElement
+    >();
+    let defaultRowHeight = isDisplayingSmallFont ? SMALL_ROW_HEIGHT : TALL_ROW_HEIGHT;
+    if (shouldDisplayThumbnailView) defaultRowHeight = measuredWidth / fileGridColumnCount;
     const { className, fileSet, isRoot, rowHeight, sortOrder } = defaults({}, props, DEFAULTS, {
-        rowHeight: isDisplayingSmallFont ? 18 : 22,
+        rowHeight: defaultRowHeight,
     });
 
     const onSelect = useFileSelector(fileSet, sortOrder);
@@ -58,24 +70,29 @@ export default function FileList(props: FileListProps) {
     // 100% of the height of its container.
     // Otherwise, the height of the list should reflect the number of items it has to render, up to
     // a certain maximum.
-    const [measuredNodeRef, measuredHeight, measuredWidth] = useLayoutMeasurements<
-        HTMLDivElement
-    >();
     const dataDrivenHeight = rowHeight * (totalCount || DEFAULT_TOTAL_COUNT) + 3 * rowHeight; // adding three additional rowHeights leaves room for the header + horz. scroll bar
     const calculatedHeight = Math.min(MAX_NON_ROOT_HEIGHT, dataDrivenHeight);
     const height = isRoot ? measuredHeight : calculatedHeight;
 
     const listRef = React.useRef<FixedSizeList | null>(null);
+    const gridRef = React.useRef<FixedSizeGrid | null>(null);
     const outerRef = React.useRef<HTMLDivElement | null>(null);
 
     // This hook is responsible for ensuring that if the details pane is currently showing a file row
     // within this FileList the file row shown in the details pane is scrolled into view.
     React.useEffect(() => {
-        if (listRef.current && outerRef.current && fileSelection.isFocused(fileSet)) {
+        if (
+            (listRef.current || gridRef.current) &&
+            outerRef.current &&
+            fileSelection.isFocused(fileSet)
+        ) {
             const { indexWithinFileSet } = fileSelection.getFocusedItemIndices();
             if (indexWithinFileSet !== undefined) {
                 const listScrollTop = outerRef.current.scrollTop;
-                const focusedItemTop = indexWithinFileSet * rowHeight;
+                let focusedItemTop = indexWithinFileSet * rowHeight;
+                if (gridRef.current) {
+                    focusedItemTop = (indexWithinFileSet / fileGridColumnCount) * rowHeight;
+                }
                 const focusedItemBottom = focusedItemTop + rowHeight;
                 const headerHeight = 40; // px; defined in Header.module.css; stickily sits on top of the list
                 const visibleArea = height - headerHeight;
@@ -88,11 +105,17 @@ export default function FileList(props: FileListProps) {
                     const centeredWithinVisibleArea = Math.floor(
                         centerOfFocusedItem - visibleArea / 2
                     );
-                    listRef.current.scrollTo(Math.max(0, centeredWithinVisibleArea));
+                    if (listRef.current) {
+                        listRef.current.scrollTo(Math.max(0, centeredWithinVisibleArea));
+                    } else if (gridRef.current) {
+                        gridRef.current.scrollTo({
+                            scrollTop: Math.max(0, centeredWithinVisibleArea),
+                        });
+                    }
                 }
             }
         }
-    }, [fileSelection, fileSet, height, rowHeight]);
+    }, [fileSelection, fileSet, height, fileGridColumnCount, rowHeight]);
 
     // Get a count of all files in the FileList, but don't wait on it
     React.useEffect(() => {
@@ -126,7 +149,7 @@ export default function FileList(props: FileListProps) {
                     itemCount={totalCount || DEFAULT_TOTAL_COUNT}
                 >
                     {({ onItemsRendered, ref: innerRef }) => {
-                        const callbackRef = (instance: FixedSizeList | null) => {
+                        const callbackRefList = (instance: FixedSizeList | null) => {
                             listRef.current = instance;
 
                             // react-window-infinite-loader takes a reference to the List component instance:
@@ -135,8 +158,69 @@ export default function FileList(props: FileListProps) {
                                 innerRef(instance);
                             }
                         };
+                        const callbackRefGrid = (instance: FixedSizeGrid | null) => {
+                            gridRef.current = instance;
+                            if (isFunction(innerRef)) {
+                                innerRef(instance);
+                            }
+                        };
+                        // Custom onItemsRendered for grids
+                        // The built-in onItemsRendered from InfiniteLoader only supports lists
+                        const onGridItemsRendered = (gridData: any) => {
+                            const {
+                                visibleRowStartIndex,
+                                visibleRowStopIndex,
+                                visibleColumnStopIndex,
+                                overscanRowStartIndex,
+                                overscanRowStopIndex,
+                                overscanColumnStopIndex,
+                            } = gridData;
 
-                        return (
+                            // Convert injected grid props to InfiniteLoader list props
+                            const visibleStartIndex =
+                                visibleRowStartIndex * (visibleColumnStopIndex + 1);
+                            const visibleStopIndex =
+                                visibleRowStopIndex * (visibleColumnStopIndex + 1);
+                            const overscanStartIndex =
+                                overscanRowStartIndex * (overscanColumnStopIndex + 1);
+                            const overscanStopIndex =
+                                overscanRowStopIndex * (overscanColumnStopIndex + 1);
+
+                            onItemsRendered({
+                                // call onItemsRendered from InfiniteLoader
+                                visibleStartIndex,
+                                visibleStopIndex,
+                                overscanStartIndex,
+                                overscanStopIndex,
+                            });
+                        };
+
+                        const fixedSizeGrid = (
+                            <FixedSizeGrid
+                                itemData={{
+                                    fileSet: fileSet,
+                                    onSelect,
+                                    onContextMenu: onFileRowContextMenu,
+                                    measuredWidth: measuredWidth,
+                                    itemCount: totalCount || DEFAULT_TOTAL_COUNT,
+                                }}
+                                columnCount={fileGridColumnCount}
+                                rowCount={Math.ceil(
+                                    (totalCount || DEFAULT_TOTAL_COUNT) / fileGridColumnCount
+                                )}
+                                height={height} // height of the list itself; affects number of rows rendered at any given time
+                                width={measuredWidth}
+                                rowHeight={rowHeight}
+                                columnWidth={rowHeight}
+                                outerRef={outerRef}
+                                ref={callbackRefGrid}
+                                onItemsRendered={onGridItemsRendered}
+                            >
+                                {LazilyRenderedThumbnail}
+                            </FixedSizeGrid>
+                        );
+
+                        const fixedSizeList = (
                             <FixedSizeList
                                 itemData={{
                                     fileSet: fileSet,
@@ -149,12 +233,14 @@ export default function FileList(props: FileListProps) {
                                 onItemsRendered={onItemsRendered}
                                 outerElementType={Header}
                                 outerRef={outerRef}
-                                ref={callbackRef}
+                                ref={callbackRefList}
                                 width={measuredWidth}
                             >
                                 {LazilyRenderedRow}
                             </FixedSizeList>
                         );
+
+                        return shouldDisplayThumbnailView ? fixedSizeGrid : fixedSizeList;
                     }}
                 </InfiniteLoader>
             );

--- a/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
+++ b/packages/core/components/FileList/test/LazilyRenderedThumbnail.test.tsx
@@ -1,0 +1,202 @@
+import { configureMockStore, mergeState } from "@aics/redux-utils";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { Provider } from "react-redux";
+import * as sinon from "sinon";
+
+import LazilyRenderedThumbnail from "../LazilyRenderedThumbnail";
+import { initialState } from "../../../state";
+import FileSet from "../../../entity/FileSet";
+
+describe("<LazilyRenderedThumbnail />", () => {
+    function makeItemData() {
+        const fileSet = new FileSet();
+        sinon.stub(fileSet, "getFileByIndex").callsFake((index) => {
+            if (index === 0) {
+                return {
+                    annotations: [],
+                    file_id: "abc1230",
+                    file_name: "my_image0.czi",
+                    file_path: "some/path/to/my_image0.czi",
+                    file_size: 1,
+                    thumbnail: "some/path/to/my_image0.jpg",
+                    uploaded: new Date().toISOString(),
+                };
+            }
+            if (index === 9) {
+                return {
+                    annotations: [],
+                    file_id: "abc1239",
+                    file_name: "my_image9.jpg",
+                    file_path: "some/path/to/my_image9.jpg",
+                    file_size: 1,
+                    thumbnail: "",
+                    uploaded: new Date().toISOString(),
+                };
+            }
+            if (index === 25) {
+                return {
+                    annotations: [],
+                    file_id: "abc12325",
+                    file_name: "my_image25.czi",
+                    file_path: "some/path/to/my_image25.czi",
+                    file_size: 1,
+                    thumbnail: "",
+                    uploaded: new Date().toISOString(),
+                };
+            }
+        });
+
+        return {
+            fileSet,
+            measuredWidth: 600,
+            itemCount: 100,
+            onContextMenu: sinon.spy(),
+            onSelect: sinon.spy(),
+        };
+    }
+
+    it("renders thumbnail when file has one specified", () => {
+        // Arrange
+        const state = mergeState(initialState, {});
+        const { store } = configureMockStore({ state });
+
+        // Act
+        const { getByText, getByRole } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={0}
+                    columnIndex={0}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        // Also checking for proper row/col indexing
+        const thumbnail = getByRole("img");
+        expect(thumbnail.getAttribute("src")).to.include("some/path/to/my_image0.jpg");
+        expect(getByText("my_image0.czi")).to.not.equal(null);
+    });
+
+    it("renders file as thumbnail if file is renderable type", () => {
+        // Arrange
+        const { store } = configureMockStore({ state: initialState });
+
+        // Act
+        const { getByText, getByRole } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={1}
+                    columnIndex={4}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        // Also confirms proper row/col indexing
+        const thumbnail = getByRole("img");
+        expect(thumbnail.getAttribute("src")).to.include("some/path/to/my_image9.jpg");
+        expect(getByText("my_image9.jpg")).to.not.equal(null);
+    });
+
+    it("renders svg as thumbnail if file has no renderable thumbnail", () => {
+        // Arrange
+        const { store } = configureMockStore({ state: initialState });
+
+        // Act
+        const { getByText, queryByRole } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={5}
+                    columnIndex={0}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        // Also confirms proper row/col indexing
+        expect(".no-thumbnail").to.exist;
+        expect(".svg").to.exist;
+        expect(queryByRole("img")).not.to.exist;
+        expect(getByText("my_image25.czi")).to.not.equal(null);
+    });
+
+    it("renders a loading indicator when data is not available", () => {
+        // Arrange
+        const { store } = configureMockStore({ state: initialState });
+
+        // Act
+        const { queryByText } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={2}
+                    columnIndex={3}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(queryByText("my_image")).to.equal(null);
+        expect(queryByText("Loading...")).to.not.equal(null);
+    });
+
+    // We want to be able to render empty cells past the total item count in order to fill the grid
+    it("renders an empty cell if the index is past the total item count", () => {
+        // Arrange
+        const { store } = configureMockStore({ state: initialState });
+
+        // Act
+        const { queryByText } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={20}
+                    columnIndex={5}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(queryByText("my_image")).to.equal(null);
+        expect(queryByText("Loading...")).to.equal(null);
+    });
+
+    it("renders and indexes correctly with different number of columns", () => {
+        // Arrange
+        const state = {
+            ...initialState,
+            selection: {
+                ...initialState.selection,
+                fileGridColumnCount: 10,
+            },
+        };
+        const { store } = configureMockStore({ state });
+
+        // Act
+        const { getByText } = render(
+            <Provider store={store}>
+                <LazilyRenderedThumbnail
+                    data={makeItemData()}
+                    rowIndex={2}
+                    columnIndex={5}
+                    style={{}}
+                />
+            </Provider>
+        );
+
+        // Assert
+        expect(".no-thumbnail").to.exist;
+        expect(".svg").to.exist;
+        expect(getByText("my_image25.czi")).to.not.equal(null);
+    });
+});

--- a/packages/core/constants/index.ts
+++ b/packages/core/constants/index.ts
@@ -153,3 +153,10 @@ export const SEARCHABLE_TOP_LEVEL_FILE_ANNOTATIONS = TOP_LEVEL_FILE_ANNOTATIONS.
 );
 
 export const TOP_LEVEL_FILE_ANNOTATION_NAMES = TOP_LEVEL_FILE_ANNOTATIONS.map((a) => a.name);
+
+export const THUMBNAIL_SIZE_TO_NUM_COLUMNS = {
+    LARGE: 5,
+    SMALL: 10,
+};
+
+export const RENDERABLE_IMAGE_FORMATS = [".jpg", ".jpeg", ".png", ".gif"];

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -542,3 +542,42 @@ export function adjustGlobalFontSize(shouldDisplaySmallFont: boolean): AdjustGlo
         type: ADJUST_GLOBAL_FONT_SIZE,
     };
 }
+
+/**
+ * SET_FILE_VIEW_TYPE
+ *
+ * Intention to set the file view type to thumbnail or list
+ */
+export const SET_FILE_THUMBNAIL_VIEW = makeConstant(STATE_BRANCH_NAME, "set-file-thumbnail-view");
+
+export interface SetFileThumbnailView {
+    payload: boolean;
+    type: string;
+}
+
+export function setFileThumbnailView(shouldDisplayThumbnailView: boolean): SetFileThumbnailView {
+    return {
+        payload: shouldDisplayThumbnailView,
+        type: SET_FILE_THUMBNAIL_VIEW,
+    };
+}
+
+/**
+ * SET_FILE_GRID_COLUMN_COUNT
+ */
+export const SET_FILE_GRID_COLUMN_COUNT = makeConstant(
+    STATE_BRANCH_NAME,
+    "set-file-grid-column-count"
+);
+
+export interface SetFileGridColumnCount {
+    payload: number;
+    type: string;
+}
+
+export function setFileGridColumnCount(fileGridColumnCount: number): SetFileGridColumnCount {
+    return {
+        payload: fileGridColumnCount,
+        type: SET_FILE_GRID_COLUMN_COUNT,
+    };
+}

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -2,7 +2,7 @@ import { makeReducer } from "@aics/redux-utils";
 import { castArray, difference, omit, without } from "lodash";
 
 import interaction from "../interaction";
-import { AnnotationName, PAST_YEAR_FILTER } from "../../constants";
+import { AnnotationName, PAST_YEAR_FILTER, THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
 import Annotation from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
 import FileFolder from "../../entity/FileFolder";
@@ -24,6 +24,8 @@ import {
     CHANGE_VIEW,
     SELECT_TUTORIAL,
     ADJUST_GLOBAL_FONT_SIZE,
+    SET_FILE_THUMBNAIL_VIEW,
+    SET_FILE_GRID_COLUMN_COUNT,
 } from "./actions";
 import FileSort, { SortOrder } from "../../entity/FileSort";
 import Tutorial from "../../entity/Tutorial";
@@ -38,10 +40,12 @@ export interface SelectionStateBranch {
         [index: string]: number; // columnName to widthPercent mapping
     };
     displayAnnotations: Annotation[];
+    fileGridColumnCount: number;
     fileSelection: FileSelection;
     filters: FileFilter[];
     openFileFolders: FileFolder[];
     shouldDisplaySmallFont: boolean;
+    shouldDisplayThumbnailView: boolean;
     sortColumn?: FileSort;
     tutorial?: Tutorial;
 }
@@ -57,10 +61,12 @@ export const initialState = {
         [AnnotationName.FILE_SIZE]: 0.15,
     },
     displayAnnotations: [],
+    fileGridColumnCount: THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE,
     fileSelection: new FileSelection(),
     filters: [PAST_YEAR_FILTER],
     openFileFolders: [],
     shouldDisplaySmallFont: false,
+    shouldDisplayThumbnailView: false,
     sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
 };
 
@@ -73,6 +79,14 @@ export default makeReducer<SelectionStateBranch>(
         [ADJUST_GLOBAL_FONT_SIZE]: (state, action) => ({
             ...state,
             shouldDisplaySmallFont: action.payload,
+        }),
+        [SET_FILE_THUMBNAIL_VIEW]: (state, action) => ({
+            ...state,
+            shouldDisplayThumbnailView: action.payload,
+        }),
+        [SET_FILE_GRID_COLUMN_COUNT]: (state, action) => ({
+            ...state,
+            fileGridColumnCount: action.payload,
         }),
         [SET_FILE_FILTERS]: (state, action) => ({
             ...state,

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -19,11 +19,14 @@ export const getAvailableAnnotationsForHierarchy = (state: State) =>
 export const getAvailableAnnotationsForHierarchyLoading = (state: State) =>
     state.selection.availableAnnotationsForHierarchyLoading;
 export const getColumnWidths = (state: State) => state.selection.columnWidths;
+export const getFileGridColumnCount = (state: State) => state.selection.fileGridColumnCount;
 export const getFileFilters = (state: State) => state.selection.filters;
 export const getCollection = (state: State) => state.selection.collection;
 export const getFileSelection = (state: State) => state.selection.fileSelection;
 export const getOpenFileFolders = (state: State) => state.selection.openFileFolders;
 export const getShouldDisplaySmallFont = (state: State) => state.selection.shouldDisplaySmallFont;
+export const getShouldDisplayThumbnailView = (state: State) =>
+    state.selection.shouldDisplayThumbnailView;
 export const getSortColumn = (state: State) => state.selection.sortColumn;
 export const getTutorial = (state: State) => state.selection.tutorial;
 


### PR DESCRIPTION
### Description
This allows users to toggle between a list view and two different size thumbnail views in the explorer per #69.
The main new component is `LazilyRenderedThumbnail`, which follows the patterns set by `LazilyRenderedRow.`
The major logic changes are in `FileList` (the parent component) which contains the `InfiniteLoader` component. Note: `InfiniteLoader` is an external component that only supports lists by default, so needed to add in some customization to accommodate a grid.

### Testing
Tested manually and with new unit tests.
- Made sure the row/column to standard index conversion is consistent between view types and the right file stays selected between views
- Different views still work when grouping via the annotation hierarchy
- Using shift or ctrl to select still works as expected with all view types

### To do: 
There are a couple UX things that would be great to run by someone:
- What do we want the toggle & its icons to look like? Currently they're in the top right near the font size toggle
- Do we want custom icons for different file types (e.g., csv, tiff, czi ?) Right now they all use the same default "no image" icon

### Screenshots
Large size thumbnails
<img width="1306" alt="Large thumbnails" src="https://github.com/AllenInstitute/aics-fms-file-explorer-app/assets/24441706/4310dff4-f03e-4341-894f-7a7a62d58f0f">

Small size thumbnails
<img width="1314" alt="Small thumbnails" src="https://github.com/AllenInstitute/aics-fms-file-explorer-app/assets/24441706/81af0208-2f76-4631-98c2-fd4f69ca120f">

Using annotation hierarchy to group
<img width="1710" alt="Screenshot 2024-04-15 at 11 43 19 AM" src="https://github.com/AllenInstitute/aics-fms-file-explorer-app/assets/24441706/9e575738-1624-43b5-9601-44e0bee4b078">
