### PR TITLE
feature/persistant-annotations

### DIFF
--- a/packages/core/components/AnnotationPicker/index.tsx
+++ b/packages/core/components/AnnotationPicker/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import ListPicker, { ListItem } from "../ListPicker";
 import { TOP_LEVEL_FILE_ANNOTATION_NAMES } from "../../constants";
 import Annotation from "../../entity/Annotation";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 
 interface Props {
     disabledTopLevelAnnotations?: boolean;
@@ -23,7 +23,7 @@ interface Props {
  * downloading a manifest.
  */
 export default function AnnotationPicker(props: Props) {
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
     const unavailableAnnotations = useSelector(
         selection.selectors.getUnavailableAnnotationsForHierarchy
     );

--- a/packages/core/components/FileDetails/FileAnnotationList.tsx
+++ b/packages/core/components/FileDetails/FileAnnotationList.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import FileAnnotationRow from "./FileAnnotationRow";
 import Annotation, { AnnotationName } from "../../entity/Annotation";
 import FileDetail from "../../entity/FileDetail";
-import { interaction, metadata } from "../../state";
+import { interaction, selection } from "../../state";
 
 import styles from "./FileAnnotationList.module.css";
 
@@ -21,7 +21,7 @@ interface FileAnnotationListProps {
  */
 export default function FileAnnotationList(props: FileAnnotationListProps) {
     const { className, fileDetails, isLoading } = props;
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
     const { executionEnvService } = useSelector(interaction.selectors.getPlatformDependentServices);
 
     // The path to this file on the host this application is running on

--- a/packages/core/components/QueryPart/QueryFilter.tsx
+++ b/packages/core/components/QueryPart/QueryFilter.tsx
@@ -7,7 +7,7 @@ import AnnotationPicker from "../AnnotationPicker";
 import AnnotationFilterForm from "../AnnotationFilterForm";
 import Tutorial from "../../entity/Tutorial";
 import FileFilter from "../../entity/FileFilter";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 import Annotation from "../../entity/Annotation";
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 export default function QueryFilter(props: Props) {
     const dispatch = useDispatch();
 
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
     const filtersGroupedByName = useSelector(selection.selectors.getGroupedByFilterName);
 
     return (

--- a/packages/core/components/QueryPart/QueryGroup.tsx
+++ b/packages/core/components/QueryPart/QueryGroup.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import QueryPart from ".";
 import AnnotationPicker from "../AnnotationPicker";
 import Tutorial from "../../entity/Tutorial";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 import Annotation from "../../entity/Annotation";
 
 interface Props {
@@ -17,7 +17,7 @@ interface Props {
 export default function QueryGroup(props: Props) {
     const dispatch = useDispatch();
 
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
 
     const selectedAnnotations = props.groups
         .map((annotationName) =>

--- a/packages/core/components/QueryPart/QuerySort.tsx
+++ b/packages/core/components/QueryPart/QuerySort.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import QueryPart from ".";
 import AnnotationPicker from "../AnnotationPicker";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 import FileSort, { SortOrder } from "../../entity/FileSort";
 import Tutorial from "../../entity/Tutorial";
 
@@ -17,7 +17,7 @@ interface Props {
 export default function QuerySort(props: Props) {
     const dispatch = useDispatch();
 
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
 
     return (
         <QueryPart

--- a/packages/core/components/QuerySidebar/Query.tsx
+++ b/packages/core/components/QuerySidebar/Query.tsx
@@ -9,7 +9,7 @@ import QueryFilter from "../QueryPart/QueryFilter";
 import QueryGroup from "../QueryPart/QueryGroup";
 import QuerySort from "../QueryPart/QuerySort";
 import FileExplorerURL from "../../entity/FileExplorerURL";
-import { metadata, selection } from "../../state";
+import { selection } from "../../state";
 import { Query as QueryType } from "../../state/selection/actions";
 
 import styles from "./Query.module.css";
@@ -26,7 +26,7 @@ interface QueryProps {
 export default function Query(props: QueryProps) {
     const dispatch = useDispatch();
     const queries = useSelector(selection.selectors.getQueries);
-    const annotations = useSelector(metadata.selectors.getSortedAnnotations);
+    const annotations = useSelector(selection.selectors.getSortedAnnotations);
     const currentGlobalURL = useSelector(selection.selectors.getEncodedFileExplorerUrl);
 
     const [isExpanded, setIsExpanded] = React.useState(false);

--- a/packages/core/services/PersistentConfigService/index.ts
+++ b/packages/core/services/PersistentConfigService/index.ts
@@ -12,6 +12,7 @@ export enum PersistedConfigKeys {
     HasUsedApplicationBefore = "HAS_USED_APPLICATION_BEFORE",
     UserSelectedApplications = "USER_SELECTED_APPLICATIONS",
     Queries = "QUERIES",
+    RecentAnnotations = "RECENT_ANNOTATIONS",
 }
 
 export interface UserSelectedApplication {
@@ -26,6 +27,7 @@ export interface PersistedConfig {
     [PersistedConfigKeys.ImageJExecutable]?: string; // Deprecated
     [PersistedConfigKeys.HasUsedApplicationBefore]?: boolean;
     [PersistedConfigKeys.Queries]?: Query[];
+    [PersistedConfigKeys.RecentAnnotations]?: string[];
     [PersistedConfigKeys.UserSelectedApplications]?: UserSelectedApplication[];
 }
 

--- a/packages/core/state/index.ts
+++ b/packages/core/state/index.ts
@@ -66,6 +66,8 @@ export function createReduxStore(options: CreateStoreOptions = {}) {
     const displayAnnotations = rawDisplayAnnotations
         ? rawDisplayAnnotations.map((annotation) => new Annotation(annotation))
         : [];
+    const recentAnnotations =
+        persistedConfig && persistedConfig[PersistedConfigKeys.RecentAnnotations];
     const preloadedState: State = mergeState(initialState, {
         interaction: {
             csvColumns: persistedConfig?.[PersistedConfigKeys.CsvColumns],
@@ -77,6 +79,7 @@ export function createReduxStore(options: CreateStoreOptions = {}) {
         selection: {
             displayAnnotations,
             queries,
+            recentAnnotations,
         },
     });
     return configureStore<State>({

--- a/packages/core/state/metadata/selectors.ts
+++ b/packages/core/state/metadata/selectors.ts
@@ -1,27 +1,5 @@
-import { createSelector } from "reselect";
-
 import { State } from "../";
-import Annotation, { AnnotationName } from "../../entity/Annotation";
 
 // BASIC SELECTORS
 export const getAnnotations = (state: State) => state.metadata.annotations;
 export const getCollections = (state: State) => state.metadata.collections;
-
-// COMPOSED SELECTORS
-export const getSortedAnnotations = createSelector(getAnnotations, (annotations: Annotation[]) => {
-    // Sort annotations by file name first then everything else alphabetically
-    const fileNameAnnotationIndex = annotations.findIndex(
-        (annotation) =>
-            annotation.name === AnnotationName.FILE_NAME || annotation.name === "File Name"
-    );
-    if (fileNameAnnotationIndex === -1) {
-        return Annotation.sort(annotations);
-    }
-    return [
-        annotations[fileNameAnnotationIndex],
-        ...Annotation.sort([
-            ...annotations.slice(0, fileNameAnnotationIndex),
-            ...annotations.slice(fileNameAnnotationIndex + 1),
-        ]),
-    ];
-});

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -99,8 +99,6 @@ export default makeReducer<SelectionStateBranch>(
             fileGridColumnCount: action.payload,
         }),
         [SET_FILE_FILTERS]: (state, action) => {
-            console.log("Filter: ", action.payload);
-
             const recentAnnotations = Array.from(
                 new Set([
                     // get annotaionName from each filter and add to recents

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -83,8 +83,8 @@ export const getSortedAnnotations = createSelector(
     [getAnnotations, getRecentAnnotations],
     (annotations: Annotation[], recentAnnotationNames: string[]) => {
         // Create Array of annotations from recentAnnotationNames
-        const recentAnnotations = annotations.filter((annotation) =>
-            recentAnnotationNames.includes(annotation.name)
+        const recentAnnotations = recentAnnotationNames.flatMap((name) =>
+            annotations.filter((annotation) => annotation.name === name)
         );
 
         // get the File name annotaion in a list (if Present)

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -79,6 +79,7 @@ store.subscribe(() => {
     const csvColumns = interaction.selectors.getCsvColumns(state);
     const displayAnnotations = selection.selectors.getAnnotationsToDisplay(state);
     const hasUsedApplicationBefore = interaction.selectors.hasUsedApplicationBefore(state);
+    const recentAnnotations = selection.selectors.getRecentAnnotations(state);
     const userSelectedApplications = interaction.selectors.getUserSelectedApplications(state);
 
     const appState = {
@@ -91,6 +92,7 @@ store.subscribe(() => {
         })),
         [PersistedConfigKeys.HasUsedApplicationBefore]: hasUsedApplicationBefore,
         [PersistedConfigKeys.Queries]: queries,
+        [PersistedConfigKeys.RecentAnnotations]: recentAnnotations,
         [PersistedConfigKeys.UserSelectedApplications]: userSelectedApplications,
     };
 
@@ -102,6 +104,10 @@ store.subscribe(() => {
         {}
     );
     if (JSON.stringify(appState) !== JSON.stringify(oldAppState)) {
+        if (appState.RECENT_ANNOTATIONS[0] == undefined) {
+            appState.RECENT_ANNOTATIONS = [];
+        }
+
         persistentConfigService.persist(appState);
     }
 });

--- a/packages/desktop/src/services/PersistentConfigServiceElectron.ts
+++ b/packages/desktop/src/services/PersistentConfigServiceElectron.ts
@@ -60,6 +60,13 @@ const OPTIONS: Options<Record<string, unknown>> = {
                 },
             },
         },
+        [PersistedConfigKeys.RecentAnnotations]: {
+            type: "array",
+            items: {
+                type: "string",
+            },
+        },
+
         [PersistedConfigKeys.HasUsedApplicationBefore]: {
             type: "boolean",
         },

--- a/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
+++ b/packages/desktop/src/services/test/PersistentConfigServiceElectron.test.ts
@@ -45,6 +45,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                     name: "ZEN",
                 },
             ];
+            const expectedRecentAnnotations = ["column"];
             const expectedQueries = [
                 {
                     name: "foo",
@@ -71,6 +72,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
             );
             service.persist(PersistedConfigKeys.UserSelectedApplications, expectedUserSelectedApps);
             service.persist(PersistedConfigKeys.DisplayAnnotations, expectedDisplayAnnotations);
+            service.persist(PersistedConfigKeys.RecentAnnotations, expectedRecentAnnotations);
 
             const expectedConfig = {
                 [PersistedConfigKeys.AllenMountPoint]: expectedAllenMountPoint,
@@ -80,6 +82,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                 [PersistedConfigKeys.HasUsedApplicationBefore]: expectedHasUsedApplicationBefore,
                 [PersistedConfigKeys.UserSelectedApplications]: expectedUserSelectedApps,
                 [PersistedConfigKeys.DisplayAnnotations]: expectedDisplayAnnotations,
+                [PersistedConfigKeys.RecentAnnotations]: expectedRecentAnnotations,
             };
 
             // Act
@@ -116,6 +119,7 @@ describe(`${RUN_IN_RENDERER} PersistentConfigServiceElectron`, () => {
                         units: "string",
                     },
                 ],
+                [PersistedConfigKeys.RecentAnnotations]: ["column"],
             };
 
             // Act


### PR DESCRIPTION
### Description of Changes 

This PR proposes prioritizing recently used Groups, Filters, and Sorts in the ordering of their respective selection dropdowns ( resolves #57 ). This PR is a continuation of #76  feature/recent-hierarchy-annotations , but is based on the new generalize-ui #79 branch.


### Testing 

Monitored state through various selections and deselections of Groups, Filters, and Sorts including those with repeated no-file-found options.

I did experience some issues with reloading the application where it would disconnect on the first reload but succeed on the second reload. I believe this is an inherent issue to the base branch or my development environment as is still present without these changes.

This PR also passes tests locally with the exception of 
```
  9) @renderer FileDownloadServiceElectron
       promptForDownloadDirectory
         complains about non-writeable directory when given:
     Error: Trying to stub property 'invoke' of undefined

```
I believe that this is unique to my local environment since I had to use WSL to run the full test suite. In reviewing this PR it would be super helpful to run tests locally with your dev env just to make sure everything is Ok.

### Possible Changes/Adjustments 

1) Limiting the length of recent annotations to a smaller number, I foresee a situation where a user has a lot of interaction and the recent list becomes very long (and unalphabetized) and this feature becomes a hindrance 
2) A adjustment to ‘On Start” state to not include undefined elements.
