### PR TITLE
feature/gh-issues-and-forum-links

### DIFF
--- a/packages/core/components/QuerySidebar/tutorials/index.ts
+++ b/packages/core/components/QuerySidebar/tutorials/index.ts
@@ -40,7 +40,7 @@ export const HELP_OPTIONS = (dispatch: Dispatch): IContextualMenuItem[] => {
                 iconName: "AccountActivity",
             },
             title: "Opens image.sc forums",
-            href: "https://forum.image.sc/",
+            href: "https://forum.image.sc/tag/biofile-finder",
             target: "_blank",
         },
         {

--- a/packages/core/components/QuerySidebar/tutorials/index.ts
+++ b/packages/core/components/QuerySidebar/tutorials/index.ts
@@ -25,11 +25,11 @@ export const HELP_OPTIONS = (dispatch: Dispatch): IContextualMenuItem[] => {
         },
         {
             key: "gh-issues-page",
-            text: "Submit Issue",
+            text: "Report an Issue",
             iconProps: {
                 iconName: "Bug",
             },
-            title: "Opens the FMS File Explorer GH issues page",
+            title: "Opens the FMS File Explorer GitHub issues page",
             href: "https://github.com/AllenInstitute/aics-fms-file-explorer-app/issues",
             target: "_blank",
         },

--- a/packages/core/components/QuerySidebar/tutorials/index.ts
+++ b/packages/core/components/QuerySidebar/tutorials/index.ts
@@ -24,6 +24,26 @@ export const HELP_OPTIONS = (dispatch: Dispatch): IContextualMenuItem[] => {
             target: "_blank",
         },
         {
+            key: "gh-issues-page",
+            text: "Submit Issue",
+            iconProps: {
+                iconName: "Bug",
+            },
+            title: "Opens the FMS File Explorer GH issues page",
+            href: "https://github.com/AllenInstitute/aics-fms-file-explorer-app/issues",
+            target: "_blank",
+        },
+        {
+            key: "image-sc",
+            text: "Access Forums",
+            iconProps: {
+                iconName: "AccountActivity",
+            },
+            title: "Opens image.sc forums",
+            href: "https://forum.image.sc/",
+            target: "_blank",
+        },
+        {
             key: "tutorials",
             text: "Tutorials",
             iconProps: {


### PR DESCRIPTION
This PR adds in two links to the HELP_OPTIONS dropdown at the bottom of the app. The first is to our GH issues page and the other is to image.sc for futute forums. This PR aims to resolve #90 