### PR TITLE
Feature/Make fuzzy search optional

### DIFF
--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -53,7 +53,9 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     }, [props.annotation, annotationValues, filtersForAnnotation]);
 
     const fuzzySearchEnabled = React.useMemo(() => {
-        return fuzzyFilters.some((filter) => filter.annotationName === props.annotation.name);
+        return (
+            fuzzyFilters?.some((filter) => filter.annotationName === props.annotation.name) || false
+        );
     }, [fuzzyFilters, props.annotation]);
 
     const onEnableFuzzySearch = () => {

--- a/packages/core/components/AnnotationFilterForm/index.tsx
+++ b/packages/core/components/AnnotationFilterForm/index.tsx
@@ -7,6 +7,7 @@ import useAnnotationValues from "./useAnnotationValues";
 import Annotation, { AnnotationName } from "../../entity/Annotation";
 import { AnnotationType } from "../../entity/AnnotationFormatter";
 import FileFilter from "../../entity/FileFilter";
+import FileFuzzyFilter from "../../entity/FileFuzzyFilter";
 import ListPicker from "../ListPicker";
 import { ListItem } from "../ListPicker/ListRow";
 import NumberRangePicker from "../NumberRangePicker";
@@ -29,6 +30,7 @@ interface AnnotationFilterFormProps {
 export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
     const dispatch = useDispatch();
     const allFilters = useSelector(selection.selectors.getFileFilters);
+    const fuzzyFilters = useSelector(selection.selectors.getFileFuzzyFilters);
     const annotationService = useSelector(interaction.selectors.getAnnotationService);
     const [annotationValues, isLoading, errorMessage] = useAnnotationValues(
         props.annotation.name,
@@ -49,6 +51,20 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
             value,
         }));
     }, [props.annotation, annotationValues, filtersForAnnotation]);
+
+    const fuzzySearchEnabled = React.useMemo(() => {
+        return fuzzyFilters.some((filter) => filter.annotationName === props.annotation.name);
+    }, [fuzzyFilters, props.annotation]);
+
+    const onEnableFuzzySearch = () => {
+        const fuzzyFilter = new FileFuzzyFilter(props.annotation.name);
+        dispatch(selection.actions.addFileFuzzyFilter(fuzzyFilter));
+    };
+
+    const onDisableFuzzySearch = () => {
+        const fuzzyFilter = new FileFuzzyFilter(props.annotation.name);
+        dispatch(selection.actions.removeFileFuzzyFilter(fuzzyFilter));
+    };
 
     const onDeselectAll = () => {
         dispatch(selection.actions.removeFileFilter(filtersForAnnotation));
@@ -157,9 +173,12 @@ export default function AnnotationFilterForm(props: AnnotationFilterFormProps) {
             return (
                 <SearchBoxForm
                     className={styles.picker}
+                    onDisableFuzzySearch={onDisableFuzzySearch}
+                    onEnableFuzzySearch={onEnableFuzzySearch}
                     onSearch={onSearch}
                     onReset={onDeselectAll}
                     fieldName={props.annotation.displayName}
+                    fuzzySearchEnabled={fuzzySearchEnabled}
                     title={`Filter by ${props.annotation.displayName}`}
                     currentValue={filtersForAnnotation?.[0]}
                 />

--- a/packages/core/components/DirectoryTree/index.tsx
+++ b/packages/core/components/DirectoryTree/index.tsx
@@ -39,14 +39,16 @@ export default function DirectoryTree(props: FileListProps) {
     const dispatch = useDispatch();
     const fileService = useSelector(interaction.selectors.getFileService);
     const globalFilters = useSelector(selection.selectors.getFileFilters);
+    const fuzzyFilters = useSelector(selection.selectors.getFileFuzzyFilters);
     const sortColumn = useSelector(selection.selectors.getSortColumn);
     const fileSet = React.useMemo(() => {
         return new FileSet({
             fileService: fileService,
             filters: globalFilters,
+            fuzzyFilters,
             sort: sortColumn,
         });
-    }, [fileService, globalFilters, sortColumn]);
+    }, [fileService, fuzzyFilters, globalFilters, sortColumn]);
 
     // On a up arrow key or down arrow key press this event will update the file list selection & focused file
     // to be either the row above (if the up arrow was pressed) or the row below (if the down arrow was pressed)

--- a/packages/core/components/SearchBoxForm/SearchBoxForm.module.css
+++ b/packages/core/components/SearchBoxForm/SearchBoxForm.module.css
@@ -21,12 +21,16 @@
     display: flex;
     flex-direction: row;
     align-content: center;
-    font-size: 16px;
-    margin-bottom: var(--spacing);
+    font-size: 14px;
+    margin-top: var(--margin);
     cursor: pointer;
 }
 
 .checkbox {
-    margin-right: var(--spacing);
+    margin: 2px 4px 1px 0;
     cursor: pointer;
+}
+
+input[type=checkbox] {
+    accent-color: var(--dark-purple);
 }

--- a/packages/core/components/SearchBoxForm/SearchBoxForm.module.css
+++ b/packages/core/components/SearchBoxForm/SearchBoxForm.module.css
@@ -16,3 +16,17 @@
     margin: 0;
     padding-bottom: var(--margin);
 }
+
+.checkbox-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    font-size: 16px;
+    margin-bottom: var(--spacing);
+    cursor: pointer;
+}
+
+.checkbox {
+    margin-right: var(--spacing);
+    cursor: pointer;
+}

--- a/packages/core/components/SearchBoxForm/index.tsx
+++ b/packages/core/components/SearchBoxForm/index.tsx
@@ -8,9 +8,12 @@ import styles from "./SearchBoxForm.module.css";
 interface SearchBoxFormProps {
     className?: string;
     title?: string;
+    onDisableFuzzySearch: () => void;
+    onEnableFuzzySearch: () => void;
     onSearch: (filterValue: string) => void;
     onReset: () => void;
     fieldName: string;
+    fuzzySearchEnabled: boolean;
     currentValue: FileFilter | undefined;
 }
 
@@ -24,7 +27,15 @@ const SEARCH_BOX_STYLE_OVERRIDES = {
  * This component renders a simple form for searching on text values
  */
 export default function SearchBoxForm(props: SearchBoxFormProps) {
-    const { onSearch, onReset, fieldName, currentValue } = props;
+    const {
+        onDisableFuzzySearch,
+        onEnableFuzzySearch,
+        onSearch,
+        onReset,
+        fieldName,
+        fuzzySearchEnabled,
+        currentValue,
+    } = props;
 
     const [searchValue, setSearchValue] = React.useState(currentValue?.value ?? "");
 
@@ -51,6 +62,26 @@ export default function SearchBoxForm(props: SearchBoxFormProps) {
                 onChange={onSearchBoxChange}
                 value={searchValue}
             />
+            {/* TODO: Improve UI */}
+            <label className={styles.checkboxWrapper}>
+                <input
+                    className={styles.checkbox}
+                    type="checkbox"
+                    role="checkbox"
+                    name="Enable fuzzy search"
+                    value={fieldName}
+                    checked={fuzzySearchEnabled}
+                    aria-checked={fuzzySearchEnabled}
+                    onChange={(event) => {
+                        if (event.target.checked) {
+                            onEnableFuzzySearch();
+                        } else {
+                            onDisableFuzzySearch();
+                        }
+                    }}
+                />
+                Enable fuzzy search
+            </label>
         </div>
     );
 }

--- a/packages/core/components/SearchBoxForm/test/SearchBoxForm.test.tsx
+++ b/packages/core/components/SearchBoxForm/test/SearchBoxForm.test.tsx
@@ -13,6 +13,9 @@ describe("<SearchBoxForm />", () => {
         const { getAllByRole } = render(
             <SearchBoxForm
                 fieldName={"Example Field"}
+                fuzzySearchEnabled={false}
+                onDisableFuzzySearch={noop}
+                onEnableFuzzySearch={noop}
                 onSearch={noop}
                 onReset={noop}
                 currentValue={undefined}
@@ -29,6 +32,9 @@ describe("<SearchBoxForm />", () => {
         render(
             <SearchBoxForm
                 fieldName={"foo"}
+                fuzzySearchEnabled={false}
+                onDisableFuzzySearch={noop}
+                onEnableFuzzySearch={noop}
                 onSearch={noop}
                 onReset={noop}
                 currentValue={currentValue}
@@ -48,6 +54,9 @@ describe("<SearchBoxForm />", () => {
         const { getByRole, getByLabelText } = render(
             <SearchBoxForm
                 fieldName={"foo"}
+                fuzzySearchEnabled={false}
+                onDisableFuzzySearch={noop}
+                onEnableFuzzySearch={noop}
                 onSearch={onSearch}
                 onReset={onReset}
                 currentValue={undefined}

--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -79,7 +79,8 @@ export default class FileExplorerURL {
     public static encode(urlComponents: Partial<FileExplorerURLComponents>) {
         const groupBy = urlComponents.hierarchy?.map((annotation) => annotation) || [];
         const filters = urlComponents.filters?.map((filter) => filter.toJSON()) || [];
-        const fuzzyFilters = urlComponents.fuzzyFilters?.map((fuzzyFilter) => fuzzyFilter) || [];
+        const fuzzyFilters =
+            urlComponents.fuzzyFilters?.map((fuzzyFilter) => fuzzyFilter) || undefined;
         const openFolders = urlComponents.openFolders?.map((folder) => folder.fileFolder) || [];
         const sort = urlComponents.sortColumn
             ? {
@@ -146,7 +147,7 @@ export default class FileExplorerURL {
 
         const hierarchyDepth = parsedURL.groupBy.length;
 
-        let fuzzyFilters: FileFuzzyFilter[] = [];
+        let fuzzyFilters: FileFuzzyFilter[] | undefined = undefined;
         if (parsedURL.fuzzyFilters) {
             fuzzyFilters = parsedURL.fuzzyFilters.map((fuzzyFilter) => {
                 return new FileFuzzyFilter(fuzzyFilter.annotationName);

--- a/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
+++ b/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
@@ -4,6 +4,7 @@ import FileExplorerURL, { FileExplorerURLComponents } from "..";
 import { Dataset } from "../../../services/DatasetService";
 import { AnnotationName } from "../../Annotation";
 import FileFilter from "../../FileFilter";
+import FileFuzzyFilter from "../../FileFuzzyFilter";
 import FileFolder from "../../FileFolder";
 import FileSort, { SortOrder } from "../../FileSort";
 
@@ -28,6 +29,10 @@ describe("FileExplorerURL", () => {
                 { name: "Cas9", value: "spCas9" },
                 { name: "Donor Plasmid", value: "ACTB-mEGFP" },
             ];
+            const expectedFuzzyFilters = [
+                { annotationName: AnnotationName.FILE_NAME },
+                { annotationName: AnnotationName.FILE_PATH },
+            ];
             const expectedOpenFolders = [
                 ["AICS-0"],
                 ["AICS-0", "ACTB-mEGFP"],
@@ -41,6 +46,9 @@ describe("FileExplorerURL", () => {
             const components: FileExplorerURLComponents = {
                 hierarchy: expectedAnnotationNames,
                 filters: expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
+                fuzzyFilters: expectedFuzzyFilters.map(
+                    (fuzzyFilter) => new FileFuzzyFilter(fuzzyFilter.annotationName)
+                ),
                 openFolders: expectedOpenFolders.map((folder) => new FileFolder(folder)),
                 sortColumn: new FileSort(AnnotationName.FILE_SIZE, SortOrder.DESC),
                 collection: {
@@ -53,6 +61,7 @@ describe("FileExplorerURL", () => {
                 JSON.stringify({
                     groupBy: expectedAnnotationNames,
                     filters: expectedFilters,
+                    fuzzyFilters: expectedFuzzyFilters,
                     openFolders: expectedOpenFolders,
                     sort: expectedSort,
                     collection: {
@@ -99,6 +108,10 @@ describe("FileExplorerURL", () => {
                 { name: "Cas9", value: "spCas9" },
                 { name: "Donor Plasmid", value: "ACTB-mEGFP" },
             ];
+            const expectedFuzzyFilters = [
+                { annotationName: AnnotationName.FILE_NAME },
+                { annotationName: AnnotationName.FILE_PATH },
+            ];
             const expectedOpenFolders = [
                 ["3500000654"],
                 ["3500000654", "ACTB-mEGFP"],
@@ -108,6 +121,9 @@ describe("FileExplorerURL", () => {
             const components: FileExplorerURLComponents = {
                 hierarchy: expectedAnnotationNames,
                 filters: expectedFilters.map(({ name, value }) => new FileFilter(name, value)),
+                fuzzyFilters: expectedFuzzyFilters.map(
+                    (fuzzyFilter) => new FileFuzzyFilter(fuzzyFilter.annotationName)
+                ),
                 openFolders: expectedOpenFolders.map((folder) => new FileFolder(folder)),
                 sortColumn: new FileSort(AnnotationName.UPLOADED, SortOrder.DESC),
                 collection: {
@@ -131,6 +147,7 @@ describe("FileExplorerURL", () => {
                 hierarchy: [],
                 filters: [],
                 openFolders: [],
+                fuzzyFilters: undefined,
                 sortColumn: undefined,
                 collection: undefined,
             };

--- a/packages/core/entity/FileFuzzyFilter/index.ts
+++ b/packages/core/entity/FileFuzzyFilter/index.ts
@@ -1,0 +1,19 @@
+/**
+ * A simple container to represent a fuzzy filter to apply to a file set.
+ * Responsible for serializing itself into a URL query string friendly format.
+ */
+export default class FileFuzzyFilter {
+    public readonly annotationName: string;
+
+    constructor(annotationName: string) {
+        this.annotationName = annotationName;
+    }
+
+    public toQueryString(): string {
+        return `fuzzy=${this.annotationName}`;
+    }
+
+    public equals(other?: FileFuzzyFilter): boolean {
+        return !!other && this.annotationName === other.annotationName;
+    }
+}

--- a/packages/core/state/selection/actions.ts
+++ b/packages/core/state/selection/actions.ts
@@ -9,6 +9,7 @@ import FileSort from "../../entity/FileSort";
 import NumericRange from "../../entity/NumericRange";
 import Tutorial from "../../entity/Tutorial";
 import { Dataset } from "../../services/DatasetService";
+import FileFuzzyFilter from "../../entity/FileFuzzyFilter";
 
 const STATE_BRANCH_NAME = "selection";
 
@@ -68,6 +69,69 @@ export function removeFileFilter(filter: FileFilter | FileFilter[]): RemoveFileF
     return {
         payload: filter,
         type: REMOVE_FILE_FILTER,
+    };
+}
+
+/**
+ * SET_FILE_FUZZY_FILTERS
+ *
+ * Intention to set, wholesale, a list of FileFuzzyFilters into application state. This should not be dispatched
+ * by UI components; dispatch either an ADD_FILE_FUZZY_FILTER or REMOVE_FILE_FUZZY_FILTER action. Those actions will
+ * trigger the `modifyFileFuzzyFilters` logic, which will then dispatch this action.
+ */
+export const SET_FILE_FUZZY_FILTERS = makeConstant(STATE_BRANCH_NAME, "set-file-fuzzy-filters");
+
+export interface SetFileFuzzyFiltersAction {
+    payload?: FileFuzzyFilter[];
+    type: string;
+}
+
+export function setFileFuzzyFilters(fuzzyFilters?: FileFuzzyFilter[]): SetFileFuzzyFiltersAction {
+    return {
+        payload: fuzzyFilters,
+        type: SET_FILE_FUZZY_FILTERS,
+    };
+}
+
+/**
+ * ADD_FILE_FUZZY_FILTER
+ *
+ * Intention to apply a FileFuzzyFilter.
+ */
+export const ADD_FILE_FUZZY_FILTER = makeConstant(STATE_BRANCH_NAME, "add-file-fuzzy-filter");
+
+export interface AddFileFuzzyFilterAction {
+    payload: FileFuzzyFilter | FileFuzzyFilter[];
+    type: string;
+}
+
+export function addFileFuzzyFilter(
+    filter: FileFuzzyFilter | FileFuzzyFilter[]
+): AddFileFuzzyFilterAction {
+    return {
+        payload: filter,
+        type: ADD_FILE_FUZZY_FILTER,
+    };
+}
+
+/**
+ * REMOVE_FILE_FUZZY_FILTER
+ *
+ * Intention to remove a currently applied FileFuzzyFilter.
+ */
+export const REMOVE_FILE_FUZZY_FILTER = makeConstant(STATE_BRANCH_NAME, "remove-file-fuzzy-filter");
+
+export interface RemoveFileFuzzyFilterAction {
+    payload: FileFuzzyFilter | FileFuzzyFilter[];
+    type: string;
+}
+
+export function removeFileFuzzyFilter(
+    filter: FileFuzzyFilter | FileFuzzyFilter[]
+): RemoveFileFuzzyFilterAction {
+    return {
+        payload: filter,
+        type: REMOVE_FILE_FUZZY_FILTER,
     };
 }
 

--- a/packages/core/state/selection/logics.ts
+++ b/packages/core/state/selection/logics.ts
@@ -274,7 +274,7 @@ const modifyFileFuzzyFilters = createLogic({
     transform(deps: ReduxLogicDeps, next, reject) {
         const { action, getState } = deps;
 
-        const previousFuzzyFilters = selectionSelectors.getFileFuzzyFilters(getState());
+        const previousFuzzyFilters = selectionSelectors.getFileFuzzyFilters(getState()) || [];
         let nextFuzzyFilters: FileFuzzyFilter[];
 
         const incomingFilters = castArray(action.payload);

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -49,7 +49,7 @@ export interface SelectionStateBranch {
     fileGridColumnCount: number;
     fileSelection: FileSelection;
     filters: FileFilter[];
-    fuzzyFilters: FileFuzzyFilter[];
+    fuzzyFilters?: FileFuzzyFilter[];
     isDarkTheme: boolean;
     openFileFolders: FileFolder[];
     selectedQuery?: Query;

--- a/packages/core/state/selection/reducer.ts
+++ b/packages/core/state/selection/reducer.ts
@@ -5,6 +5,7 @@ import interaction from "../interaction";
 import { THUMBNAIL_SIZE_TO_NUM_COLUMNS } from "../../constants";
 import Annotation, { AnnotationName } from "../../entity/Annotation";
 import FileFilter from "../../entity/FileFilter";
+import FileFuzzyFilter from "../../entity/FileFuzzyFilter";
 import FileFolder from "../../entity/FileFolder";
 import FileSelection from "../../entity/FileSelection";
 
@@ -13,6 +14,7 @@ import {
     SET_ANNOTATION_HIERARCHY,
     SET_AVAILABLE_ANNOTATIONS,
     SET_FILE_FILTERS,
+    SET_FILE_FUZZY_FILTERS,
     SET_FILE_SELECTION,
     SET_OPEN_FILE_FOLDERS,
     RESIZE_COLUMN,
@@ -47,6 +49,7 @@ export interface SelectionStateBranch {
     fileGridColumnCount: number;
     fileSelection: FileSelection;
     filters: FileFilter[];
+    fuzzyFilters: FileFuzzyFilter[];
     isDarkTheme: boolean;
     openFileFolders: FileFolder[];
     selectedQuery?: Query;
@@ -72,6 +75,7 @@ export const initialState = {
     fileGridColumnCount: THUMBNAIL_SIZE_TO_NUM_COLUMNS.LARGE,
     fileSelection: new FileSelection(),
     filters: [],
+    fuzzyFilters: [],
     openFileFolders: [],
     shouldDisplaySmallFont: false,
     queries: [],
@@ -102,6 +106,10 @@ export default makeReducer<SelectionStateBranch>(
 
             // Reset file selections when file filters change
             fileSelection: new FileSelection(),
+        }),
+        [SET_FILE_FUZZY_FILTERS]: (state, action) => ({
+            ...state,
+            fuzzyFilters: action.payload,
         }),
         [SORT_COLUMN]: (state, action) => {
             if (state.sortColumn?.annotationName === action.payload) {

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -39,16 +39,16 @@ export const getEncodedFileExplorerUrl = createSelector(
     [
         getAnnotationHierarchy,
         getFileFilters,
-        getFileFuzzyFilters,
         getOpenFileFolders,
+        getFileFuzzyFilters,
         getSortColumn,
         getCollection,
     ],
     (
         hierarchy: string[],
         filters: FileFilter[],
-        fuzzyFilters: FileFuzzyFilter[],
         openFolders: FileFolder[],
+        fuzzyFilters?: FileFuzzyFilter[],
         sortColumn?: FileSort,
         collection?: Dataset
     ) => {

--- a/packages/core/state/selection/selectors.ts
+++ b/packages/core/state/selection/selectors.ts
@@ -5,6 +5,7 @@ import { State } from "../";
 import Annotation from "../../entity/Annotation";
 import FileExplorerURL from "../../entity/FileExplorerURL";
 import FileFilter from "../../entity/FileFilter";
+import FileFuzzyFilter from "../../entity/FileFuzzyFilter";
 import FileFolder from "../../entity/FileFolder";
 import FileSort from "../../entity/FileSort";
 import { Dataset } from "../../services/DatasetService";
@@ -20,6 +21,7 @@ export const getAvailableAnnotationsForHierarchyLoading = (state: State) =>
 export const getColumnWidths = (state: State) => state.selection.columnWidths;
 export const getFileGridColumnCount = (state: State) => state.selection.fileGridColumnCount;
 export const getFileFilters = (state: State) => state.selection.filters;
+export const getFileFuzzyFilters = (state: State) => state.selection.fuzzyFilters;
 export const getCollection = (state: State) => state.selection.collection;
 export const getFileSelection = (state: State) => state.selection.fileSelection;
 export const getIsDarkTheme = (state: State) => state.selection.isDarkTheme;
@@ -34,10 +36,18 @@ export const getQueries = (state: State) => state.selection.queries;
 
 // COMPOSED SELECTORS
 export const getEncodedFileExplorerUrl = createSelector(
-    [getAnnotationHierarchy, getFileFilters, getOpenFileFolders, getSortColumn, getCollection],
+    [
+        getAnnotationHierarchy,
+        getFileFilters,
+        getFileFuzzyFilters,
+        getOpenFileFolders,
+        getSortColumn,
+        getCollection,
+    ],
     (
         hierarchy: string[],
         filters: FileFilter[],
+        fuzzyFilters: FileFuzzyFilter[],
         openFolders: FileFolder[],
         sortColumn?: FileSort,
         collection?: Dataset
@@ -45,6 +55,7 @@ export const getEncodedFileExplorerUrl = createSelector(
         return FileExplorerURL.encode({
             hierarchy,
             filters,
+            fuzzyFilters,
             openFolders,
             sortColumn,
             collection,


### PR DESCRIPTION
### Description
This is a draft of the UI side of the work to have search be exact by default with the option to toggle fuzzy search in the search modal. _**This should not be merged until the FES changes are deployed**_, I'm just opening the PR to a stable state so it can be picked up again

### Changes
- Added the fuzzy search parameter to state and as a `FileExplorerURL` parameter
- Currently have a placeholder checkbox to allow users to toggle fuzzy search

Here's what the shareable link would look like now:
`fms-file-explorer://{"groupBy":[],"filters":[{"name":"uploaded","value":"RANGE(2023-05-13T07:00:00.000Z,2024-05-14T06:59:59.501Z)"},{"name":"file_name","value":"test"}],"fuzzyFilters":[{"annotationName":"file_name"}],"openFolders":[],"sort":{"annotationName":"uploaded","order":"DESC"}}`

Which would generate the following url query: `from=0&limit=56&file_name=test&uploaded=RANGE(2023-05-13T07:00:00.000Z,2024-05-14T06:59:59.501Z)&sort=uploaded(DESC)&fuzzy=file_name`

### Testing
Tested manually with an EC2 instance of FES (the local version has the fuzzy search changes, but hasn't been deployed) and staging version of Mongo.
Updated unit tests

### Screenshot
<img width="1188" alt="image" src="https://github.com/AllenInstitute/aics-fms-file-explorer-app/assets/24441706/df65086d-8f22-4ba9-83c2-1c7d58e81399">
