### PR TITLE
Add analytics to webapp

### DIFF
--- a/packages/web/webpack/index.html
+++ b/packages/web/webpack/index.html
@@ -4,9 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="logo.png" />
+    <!-- Google Tag Manager -->
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            }); var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-KCCN6L4X');</script>
+    <!-- End Google Tag Manager -->
     <title>File Explorer</title>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KCCN6L4X" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main id="fms-file-explorer-web"></main>
 </body>
 </html>


### PR DESCRIPTION
This adds Google Tag Manager to the webapp to collect basic data about user traffic/interaction.
closes #116 

### Testing
Checked that gtm is showing up with a 200 in the Network tab for all the current routes.
Once these changes are deployed, we'll need to reach out to Thao to verify its presence

### Notes
- Do we need to implement page/event tracking for React Router? 
  Edit: It sounds like most things will be configured through the Google Tag Manager interface itself, and then we can chat with the analytics team if we need something more advanced than what it currently will do
- As is, will get data from everywhere this is deployed, including dev/staging. May need to decide later if we want to keep it that way or narrow down where we collect