### PR TITLE
Prevent duplicate query creation on desktop

### DIFF
--- a/packages/core/state/interaction/logics.ts
+++ b/packages/core/state/interaction/logics.ts
@@ -50,6 +50,7 @@ const checkAicsEmployee = createLogic({
     type: INITIALIZE_APP,
     async process(deps: ReduxLogicDeps, dispatch, done) {
         const queries = selection.selectors.getQueries(deps.getState());
+        const isOnWeb = interactionSelectors.isOnWeb(deps.getState());
         const selectedQuery = selection.selectors.getSelectedQuery(deps.getState());
         const fileService = interactionSelectors.getHttpFileService(deps.getState());
 
@@ -61,7 +62,7 @@ const checkAicsEmployee = createLogic({
         if (!selectedQuery) {
             // If there are query args representing a query we can extract that
             // into the query to render (ex. when refreshing a page)
-            if (window.location.search) {
+            if (isOnWeb && window.location.search) {
                 dispatch(
                     selection.actions.addQuery({
                         name: "New Query",


### PR DESCRIPTION
**Description**
On desktop the query args were being used to create a duplicate query on refresh. In general we don't really want to use the query args on the desktop so I just added a check to make sure we were on web being this conditional path was allowed.

**Testing**
Tested this on desktop and on web. Unsure of a way to mock the `window.location.search` in unit tests so for now I could not add a test for this 😢 if you have any ideas of how to do so lmk

**Related Issue**
Resolves #133 