### PR TITLE
Fix alignment of show more button based on where shown

### DIFF
--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -41,6 +41,10 @@
     justify-content: center;
 }
 
+.left-align {
+    justify-content: left;
+}
+
 .title {
     font-weight: 100;
 }

--- a/packages/core/components/DataSourcePrompt/index.tsx
+++ b/packages/core/components/DataSourcePrompt/index.tsx
@@ -136,7 +136,11 @@ export default function DataSourcePrompt(props: Props) {
                                 </li>
                             ))}
                         </ul>
-                        <li className={styles.subtitleButtonContainer}>
+                        <li
+                            className={classNames(styles.subtitleButtonContainer, {
+                                [styles.leftAlign]: props.hideTitle,
+                            })}
+                        >
                             <DefaultButton
                                 className={styles.subtitleButton}
                                 onClick={() => setIsDataSourceDetailExpanded(false)}
@@ -148,7 +152,11 @@ export default function DataSourcePrompt(props: Props) {
                     </ul>
                 </>
             ) : (
-                <div className={styles.subtitleButtonContainer}>
+                <div
+                    className={classNames(styles.subtitleButtonContainer, {
+                        [styles.leftAlign]: props.hideTitle,
+                    })}
+                >
                     <DefaultButton
                         className={styles.subtitleButton}
                         onClick={() => setIsDataSourceDetailExpanded(true)}


### PR DESCRIPTION
Simple fix to the "Show more" button that makes it left aligned when the rest of the text is left aligned and centered otherwise by default.