### PR TITLE
Fix resize handle

### DIFF
--- a/packages/core/App.module.css
+++ b/packages/core/App.module.css
@@ -48,7 +48,7 @@
 }
 
 .query-sidebar-and-center {
-    width: calc(80% - var(--margin));
+    width: calc(100% - var(--margin) - var(--file-details-width));
     height: 100%;
     display: flex;
 

--- a/packages/core/components/FileDetails/FileDetails.module.css
+++ b/packages/core/components/FileDetails/FileDetails.module.css
@@ -1,7 +1,6 @@
 .root {
     --pagination-height: 40px;
     --padding: 10px;
-    --resize-handle-width: 10px;
 
     background-color: var(--primary-background-color);
     color: var(--primary-text-color);
@@ -10,7 +9,7 @@
     min-width: 175px;
     max-width: 95%;
     overflow: auto;
-    width: var(--file-details-width); /* defined in App.module.css under .root{} */
+    width: var(--file-details-width); /* defined in App.module.css under .root{} and used by resize handle */
 }
 
 .expandable-transition {
@@ -42,8 +41,7 @@
 }
 
 .pagination-and-content {
-    padding: var(--padding) var(--padding) 0 var(--padding);
-    transform: translateX(calc(-1 * var(--resize-handle-width) / 2));
+    padding: 12px 12px 0 12px;
     width: 100%
 }
 
@@ -105,22 +103,21 @@
     background-color: var(--primary-background-color);
 }
 
-.file-details-content {
-    display: flex;
-    overflow-y: hidden;
-    width: 100%;
-}
 
 .resize-handle {
+    --resize-handle-width: 10px;
+
     align-items: center;
+    background: none;
+    bottom: -5px;
     border-left: 1px solid var(--border-color);
+    color: var(--highlight-background-color);
     cursor: col-resize;
     display: flex;
-    height: 100%;
-    left: 0px;
+    height: calc(100% + 12px);
+    right: calc(var(--file-details-width) - var(--resize-handle-width));
     justify-content: center;
-    padding-left: 1px;
-    position: relative;
+    position: absolute;
     width: var(--resize-handle-width);
     z-index: 11;
 }

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -99,57 +99,55 @@ export default function FileDetails(props: Props) {
             className={classNames(styles.root, styles.expandableTransition, props.className)}
             id={FILE_DETAILS_PANE_ID}
         >
-            <div className={styles.fileDetailsContent}>
-                <div
-                    className={styles.resizeHandle}
-                    onMouseDown={(e) => resizeHandleOnMouseDown(e)}
-                    // TODO:???
-                    onDoubleClick={resizeHandleDoubleClick}
-                >
-                    <div />
-                </div>
-                <div className={styles.paginationAndContent}>
-                    <Pagination className={styles.pagination} />
-                    <div className={styles.overflowContainer}>
-                        {fileDetails && (
-                            <>
-                                <div className={styles.thumbnailContainer}>
-                                    <FileThumbnail
-                                        className={styles.thumbnail}
-                                        width="100%"
-                                        // height={thumbnailHeight}
-                                        uri={fileDetails?.getPathToThumbnail()}
-                                    />
-                                </div>
-                                <div className={styles.fileActions}>
-                                    <PrimaryButton
-                                        className={styles.primaryButton}
-                                        disabled={processStatuses.some((status) =>
-                                            status.data.fileId?.includes(fileDetails.id)
-                                        )}
-                                        iconName="Download"
-                                        text="Download"
-                                        title="Download"
-                                        onClick={onDownload}
-                                    />
-                                    <PrimaryButton
-                                        className={styles.primaryButton}
-                                        iconName="OpenInNewWindow"
-                                        text="Open file"
-                                        title="Open file"
-                                        menuItems={openWithMenuItems}
-                                    />
-                                </div>
-                                <p className={styles.fileName}>{fileDetails?.name}</p>
-                                <h4>Information</h4>
-                                <FileAnnotationList
-                                    className={styles.annotationList}
-                                    fileDetails={fileDetails}
-                                    isLoading={isLoading}
+            <div
+                className={styles.resizeHandle}
+                onMouseDown={(e) => resizeHandleOnMouseDown(e)}
+                // TODO:???
+                onDoubleClick={resizeHandleDoubleClick}
+            >
+                <div />
+            </div>
+            <div className={styles.paginationAndContent}>
+                <Pagination className={styles.pagination} />
+                <div className={styles.overflowContainer}>
+                    {fileDetails && (
+                        <>
+                            <div className={styles.thumbnailContainer}>
+                                <FileThumbnail
+                                    className={styles.thumbnail}
+                                    width="100%"
+                                    // height={thumbnailHeight}
+                                    uri={fileDetails?.getPathToThumbnail()}
                                 />
-                            </>
-                        )}
-                    </div>
+                            </div>
+                            <div className={styles.fileActions}>
+                                <PrimaryButton
+                                    className={styles.primaryButton}
+                                    disabled={processStatuses.some((status) =>
+                                        status.data.fileId?.includes(fileDetails.id)
+                                    )}
+                                    iconName="Download"
+                                    text="Download"
+                                    title="Download"
+                                    onClick={onDownload}
+                                />
+                                <PrimaryButton
+                                    className={styles.primaryButton}
+                                    iconName="OpenInNewWindow"
+                                    text="Open file"
+                                    title="Open file"
+                                    menuItems={openWithMenuItems}
+                                />
+                            </div>
+                            <p className={styles.fileName}>{fileDetails?.name}</p>
+                            <h4>Information</h4>
+                            <FileAnnotationList
+                                className={styles.annotationList}
+                                fileDetails={fileDetails}
+                                isLoading={isLoading}
+                            />
+                        </>
+                    )}
                 </div>
             </div>
         </div>

--- a/packages/core/components/FileList/LazilyRenderedRow.module.css
+++ b/packages/core/components/FileList/LazilyRenderedRow.module.css
@@ -25,6 +25,10 @@
     height: 18px !important;
 }
 
+.small-font .shimmer {
+    height: 15px !important;
+}
+
 .shimmer > div {
     border-radius: var(--small-border-radius);
 }

--- a/packages/core/components/ListPicker/ListPicker.module.css
+++ b/packages/core/components/ListPicker/ListPicker.module.css
@@ -7,7 +7,6 @@
     color: var(--primary-text-color);
     height: 600px;
     max-height: 75vh;
-    max-width: 400px;
     padding: 16px 30px;
     width: 35vw;
 }

--- a/packages/core/entity/FileDetail/index.ts
+++ b/packages/core/entity/FileDetail/index.ts
@@ -190,8 +190,7 @@ export default class FileDetail {
             return undefined;
         }
 
-        // LabKey does not support HTTPS yet
         const baseURLHttp = baseURL.replace("https", "http");
-        return `${baseURLHttp}/labkey/aics_microscopy/AICS/editPlate.view?Barcode=${platebarcode}}`;
+        return `${baseURLHttp}/labkey/aics_microscopy/AICS/editPlate.view?Barcode=${platebarcode}`;
     }
 }


### PR DESCRIPTION
The resize handle was broken because the width of the rest of the app was set to a fixed `80%` which meant that it wasn't considering the adjustment from the variable `--file-details-width` which is what determines the right sidebar pane's width. After changing the width calcuation this worked, added some styling changes to make it not have strange horizontal scroll behavior.

Resolves #141 