### PR TITLE
Fix encoding a cloud source

### DIFF
--- a/packages/core/entity/FileExplorerURL/index.ts
+++ b/packages/core/entity/FileExplorerURL/index.ts
@@ -90,7 +90,10 @@ export default class FileExplorerURL {
                 "source",
                 JSON.stringify({
                     ...source,
-                    uri: source.uri instanceof String ? source.uri : undefined,
+                    uri:
+                        typeof source.uri === "string" || source.uri instanceof String
+                            ? source.uri
+                            : undefined,
                 })
             );
         });

--- a/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
+++ b/packages/core/entity/FileExplorerURL/test/fileexplorerurl.test.ts
@@ -65,6 +65,30 @@ describe("FileExplorerURL", () => {
             // Assert
             expect(result).to.be.equal("");
         });
+
+        it("encodes source URIs when 'string' type is provided", () => {
+            // Arrange
+            const components: FileExplorerURLComponents = {
+                hierarchy: [],
+                filters: [],
+                openFolders: [],
+                sources: [
+                    {
+                        name: "Fake Collection",
+                        type: "csv",
+                        uri: "fake-uri.test",
+                    },
+                ],
+            };
+
+            // Act
+            const result = FileExplorerURL.encode(components);
+
+            // Assert
+            expect(result).to.be.equal(
+                "source=%7B%22name%22%3A%22Fake+Collection%22%2C%22type%22%3A%22csv%22%2C%22uri%22%3A%22fake-uri.test%22%7D"
+            );
+        });
     });
 
     describe("decode", () => {


### PR DESCRIPTION
This prevented URIs from being encoded due to `"some URI"` not being a `String` but rather `"string"`. Added a unit test for this case. There is another bug that prevents being able to just hit the "refresh" button in your browser and having the query re-run - that'll be addressed separately.