### PR TITLE
Use regex to enable queries to search against comma separated values

### DIFF
--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -196,7 +196,9 @@ export default class FileSet {
                 sqlBuilder.where(`"${annotation}" IS NOT NULL`);
             } else {
                 sqlBuilder.where(
-                    filterValues.map((fv) => `"${annotation}" = '${fv}'`).join(") OR (")
+                    filterValues
+                        .map((fv) => `REGEXP_MATCHES("${annotation}", '(\\b${fv}\\b)') = true`)
+                        .join(") OR (")
                 );
             }
         });

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -94,7 +94,10 @@ export default class DatabaseAnnotationService implements AnnotationService {
             } else {
                 sqlBuilder.where(
                     annotationValues
-                        .map((value) => `"${annotationToFilter}" = '${value}'`)
+                        .map(
+                            (value) =>
+                                `REGEXP_MATCHES("${annotationToFilter}", '(\\b${value}\\b)') = true`
+                        )
                         .join(") OR (")
                 );
             }

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -101,10 +101,10 @@ export default class DatabaseAnnotationService implements AnnotationService {
         });
 
         const rows = await this.databaseService.query(sqlBuilder.toSQL());
-        const rowsSplitByDelimeter = rows
-            .flatMap((row) => row[annotation].split(DatabaseService.LIST_DELIMETER))
+        const rowsSplitByDelimiter = rows
+            .flatMap((row) => row[annotation].split(DatabaseService.LIST_DELIMITER))
             .map((value) => value.trim());
-        return uniq(rowsSplitByDelimeter);
+        return uniq(rowsSplitByDelimiter);
     }
 
     /**

--- a/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
+++ b/packages/core/services/AnnotationService/DatabaseAnnotationService/index.ts
@@ -1,3 +1,5 @@
+import { uniq } from "lodash";
+
 import AnnotationService, { AnnotationValue } from "..";
 import DatabaseService from "../../DatabaseService";
 import DatabaseServiceNoop from "../../DatabaseService/DatabaseServiceNoop";
@@ -41,18 +43,7 @@ export default class DatabaseAnnotationService implements AnnotationService {
      * Fetch the unique values for a specific annotation.
      */
     public async fetchValues(annotation: string): Promise<AnnotationValue[]> {
-        const select_key = "select_key";
-        const sql = new SQLBuilder()
-            .select(`DISTINCT "${annotation}" AS ${select_key}`)
-            .from(this.dataSourceNames)
-            .toSQL();
-        const rows = await this.databaseService.query(sql);
-        return [
-            ...rows.reduce((valueSet, row) => {
-                `${row[select_key]}`.split(",").forEach((value) => valueSet.add(value.trim()));
-                return valueSet;
-            }, new Set<string>()),
-        ];
+        return this.fetchFilteredValuesForAnnotation(annotation);
     }
 
     public async fetchRootHierarchyValues(
@@ -67,11 +58,15 @@ export default class DatabaseAnnotationService implements AnnotationService {
         path: string[],
         filters: FileFilter[]
     ): Promise<string[]> {
-        const filtersByAnnotation = filters.reduce((map, filter) => {
-            const annotationValues = map[filter.name] ? map[filter.name] : [];
-            annotationValues.push(filter.value);
-            return { ...map, [filter.name]: annotationValues };
-        }, {} as { [name: string]: (string | null)[] });
+        const filtersByAnnotation = filters.reduce(
+            (map, filter) => ({
+                ...map,
+                [filter.name]: map[filter.name]
+                    ? [...map[filter.name], filter.value]
+                    : [filter.value],
+            }),
+            {} as { [name: string]: (string | null)[] }
+        );
 
         hierarchy
             // Map before filter because index is important to map to the path
@@ -81,23 +76,35 @@ export default class DatabaseAnnotationService implements AnnotationService {
                 }
             });
 
+        return this.fetchFilteredValuesForAnnotation(hierarchy[path.length], filtersByAnnotation);
+    }
+
+    private async fetchFilteredValuesForAnnotation(
+        annotation: string,
+        filtersByAnnotation: { [name: string]: (string | null)[] } = {}
+    ): Promise<string[]> {
         const sqlBuilder = new SQLBuilder()
-            .select(`DISTINCT "${hierarchy[path.length]}"`)
+            .select(`DISTINCT "${annotation}"`)
             .from(this.dataSourceNames);
 
-        Object.keys(filtersByAnnotation).forEach((annotation) => {
-            const annotationValues = filtersByAnnotation[annotation];
+        Object.keys(filtersByAnnotation).forEach((annotationToFilter) => {
+            const annotationValues = filtersByAnnotation[annotationToFilter];
             if (annotationValues[0] === null) {
-                sqlBuilder.where(`"${annotation}" IS NOT NULL`);
+                sqlBuilder.where(`"${annotationToFilter}" IS NOT NULL`);
             } else {
                 sqlBuilder.where(
-                    annotationValues.map((value) => `"${annotation}" = '${value}'`).join(") OR (")
+                    annotationValues
+                        .map((value) => `"${annotationToFilter}" = '${value}'`)
+                        .join(") OR (")
                 );
             }
         });
 
         const rows = await this.databaseService.query(sqlBuilder.toSQL());
-        return rows.map((row) => row[hierarchy[path.length]]);
+        const rowsSplitByDelimeter = rows
+            .flatMap((row) => row[annotation].split(DatabaseService.LIST_DELIMETER))
+            .map((value) => value.trim());
+        return uniq(rowsSplitByDelimeter);
     }
 
     /**

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -10,7 +10,7 @@ import SQLBuilder from "../../entity/SQLBuilder";
  * Service reponsible for querying against a database
  */
 export default abstract class DatabaseService {
-    public static readonly LIST_DELIMETER = ",";
+    public static readonly LIST_DELIMITER = ",";
     private currentAggregateSource?: string;
     // Initialize with AICS FMS data source name to pretend it always exists
     protected readonly existingDataSources = new Set([AICS_FMS_DATA_SOURCE_NAME]);

--- a/packages/core/services/DatabaseService/index.ts
+++ b/packages/core/services/DatabaseService/index.ts
@@ -10,6 +10,7 @@ import SQLBuilder from "../../entity/SQLBuilder";
  * Service reponsible for querying against a database
  */
 export default abstract class DatabaseService {
+    public static readonly LIST_DELIMETER = ",";
     private currentAggregateSource?: string;
     // Initialize with AICS FMS data source name to pretend it always exists
     protected readonly existingDataSources = new Set([AICS_FMS_DATA_SOURCE_NAME]);

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -57,7 +57,7 @@ export default class DatabaseFileService implements FileService {
                               {
                                   name,
                                   values: `${values}`
-                                      .split(",")
+                                      .split(DatabaseService.LIST_DELIMETER)
                                       .map((value: string) => value.trim()),
                               },
                           ]
@@ -143,11 +143,15 @@ export default class DatabaseFileService implements FileService {
                 const subQuery = new SQLBuilder()
                     .select('"File Path"')
                     .from(this.dataSourceNames)
-                    .whereOr(
-                        Object.entries(selection.filters).map(([column, values]) => {
-                            const commaSeperatedValues = values.map((v) => `'${v}'`).join(", ");
-                            return `"${column}" IN (${commaSeperatedValues})`;
-                        })
+                    .where(
+                        Object.entries(selection.filters)
+                            .flatMap(([column, values]) =>
+                                values.map(
+                                    (value) =>
+                                        `REGEXP_MATCHES("${column}", '(\\b${value}\\b)') = true`
+                                )
+                            )
+                            .join(") OR (")
                     )
                     .offset(indexRange.start)
                     .limit(indexRange.end - indexRange.start + 1);

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -57,7 +57,7 @@ export default class DatabaseFileService implements FileService {
                               {
                                   name,
                                   values: `${values}`
-                                      .split(DatabaseService.LIST_DELIMETER)
+                                      .split(DatabaseService.LIST_DELIMITER)
                                       .map((value: string) => value.trim()),
                               },
                           ]


### PR DESCRIPTION
# Description
Antoine pointed out that there isn't a way to include multiple values per column per row (see screenshot for example). This was intended to be included as a feature from the start using a comma (",") as a delimeter. However, it seems it was forgotten in a couple places which prevents it from actually working. This changeset uses regex to search using this in mind.

<img width="260" alt="Screen Shot 2024-07-29 at 5 07 18 PM" src="https://github.com/user-attachments/assets/a88da9f5-da09-40eb-abbd-f1c7eb0aaea4">

<img width="1009" alt="Screen Shot 2024-07-29 at 5 08 13 PM" src="https://github.com/user-attachments/assets/2c525268-e456-41e1-bdd6-c4a0dba9c9f3">

Additionally, I simplified the `fetchValues` method to re-use the query code found in fetching values under a hierarchy.

# Related Issue
Resolves #185