### PR TITLE
Create footer with cookie settings button

### DIFF
--- a/packages/web/src/components/Footer/Footer.module.css
+++ b/packages/web/src/components/Footer/Footer.module.css
@@ -1,0 +1,19 @@
+.footer {
+  height: fit-content;
+  margin: 0 auto;
+  padding: var(--margin) 0;
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+}
+
+.footer-link {
+  color: var(--primary-text-color) !important;
+  border: none !important;
+  font-size: var(--s-paragraph-size) !important;
+}
+
+.footer-link:hover {
+  color: var(--highlight-text-color) !important;
+  border: 0px solid var(--primary-text-color) !important;
+  background-color: transparent !important;
+}

--- a/packages/web/src/components/Footer/Footer.module.css
+++ b/packages/web/src/components/Footer/Footer.module.css
@@ -14,6 +14,5 @@
 
 .footer-link:hover {
   color: var(--highlight-text-color) !important;
-  border: 0px solid var(--primary-text-color) !important;
   background-color: transparent !important;
 }

--- a/packages/web/src/components/Footer/index.tsx
+++ b/packages/web/src/components/Footer/index.tsx
@@ -1,0 +1,16 @@
+import classNames from "classnames";
+import * as React from "react";
+
+import styles from "./Footer.module.css";
+
+export default function Footer() {
+    return (
+        <div className={styles.footer}>
+            {/* OneTrust Cookies Settings button start */}
+            <a id="ot-sdk-btn" className={classNames("ot-sdk-show-settings", styles.footerLink)}>
+                Cookie settings
+            </a>
+            {/* OneTrust Cookies Settings button end */}
+        </div>
+    );
+}

--- a/packages/web/src/components/Home/Home.module.css
+++ b/packages/web/src/components/Home/Home.module.css
@@ -44,15 +44,6 @@
     position: relative;
 }
 
-.root {
-    margin: 0;
-    border: 0;
-    width: 100%;
-    height: calc(100% - 60px);
-    overflow-y: auto;
-    justify-content: center;
-}
-
 .section {
     border-bottom: 1px solid var(--border-color);
     padding: 24px calc(6 * var(--margin));

--- a/packages/web/src/components/Layout/Layout.module.css
+++ b/packages/web/src/components/Layout/Layout.module.css
@@ -7,3 +7,9 @@
   height: 100%;
   justify-content: center;
 }
+
+/* Scrollable content: main body plus footer */
+.scrollable {
+  height: calc(100% - 60px);
+  overflow-y: auto;
+}

--- a/packages/web/src/components/Layout/index.tsx
+++ b/packages/web/src/components/Layout/index.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { Outlet } from "react-router-dom";
+
 import Header from "../Header";
+import Footer from "../Footer";
+
 import styles from "./Layout.module.css";
 
 // Basic wrapper to maintain global header
@@ -8,7 +11,10 @@ export default function Layout() {
     return (
         <div className={styles.root}>
             <Header />
-            <Outlet />
+            <div className={styles.scrollable}>
+                <Outlet />
+                <Footer />
+            </div>
         </div>
     );
 }

--- a/packages/web/src/src.module.css
+++ b/packages/web/src/src.module.css
@@ -1,3 +1,3 @@
 .app {
-    height: calc(100% - 60px);
+    height: calc(100% - 45px);
 }


### PR DESCRIPTION
## Context
Users need to be able to re-access their cookie settings after the first time they've dismissed the pop-up. 

## Changes
- Added a footer component to web only
- Added `OneTrust` button component with custom styling overrides
- Modified some `main` styling to account for footer in scroll boundary

## Screenshots
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/ce291736-cde8-41bb-a848-ced59e3570e7">

closes #180 