### PR TITLE
Fix reg ex to account for spaces

### DIFF
--- a/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/DataSourcePrompt.module.css
@@ -36,6 +36,7 @@
 
 .link-like-button span {
     font-weight: unset;
+    margin: 0;
 }
 
 .link-like-button:hover, .link-like-button:focus {

--- a/packages/core/components/DataSourcePrompt/FilePrompt.module.css
+++ b/packages/core/components/DataSourcePrompt/FilePrompt.module.css
@@ -29,7 +29,7 @@
 
 .selected-file-button {
     color: var(--primary-text-color);
-    margin-left: auto;
+    margin-left: 10px;
 }
 
 .selected-file-button:hover {
@@ -39,7 +39,6 @@
 
 .selected-file-container {
     display: flex;
-    justify-content: center;
 }
 
 .submit-icon {

--- a/packages/core/entity/FileSet/index.ts
+++ b/packages/core/entity/FileSet/index.ts
@@ -197,7 +197,13 @@ export default class FileSet {
             } else {
                 sqlBuilder.where(
                     filterValues
-                        .map((fv) => `REGEXP_MATCHES("${annotation}", '(\\b${fv}\\b)') = true`)
+                        .map(
+                            (fv) =>
+                                // Ex. This regex will match on a value
+                                // that is at the start, middle, end, or only value in a comma separated list
+                                // of values (,\s*Position,)|(^\s*Position\s*,)|(,\s*Position\s*$)|(^\s*Position\s*$)
+                                `REGEXP_MATCHES("${annotation}", '(,\\s*${fv}\\s*,)|(^\\s*${fv}\\s*,)|(,\\s*${fv}\\s*$)|(^\\s*${fv}\\s*$)') = true`
+                        )
                         .join(") OR (")
                 );
             }

--- a/packages/core/services/FileService/DatabaseFileService/index.ts
+++ b/packages/core/services/FileService/DatabaseFileService/index.ts
@@ -148,7 +148,10 @@ export default class DatabaseFileService implements FileService {
                             .flatMap(([column, values]) =>
                                 values.map(
                                     (value) =>
-                                        `REGEXP_MATCHES("${column}", '(\\b${value}\\b)') = true`
+                                        // Ex. This regex will match on a value
+                                        // that is at the start, middle, end, or only value in a comma separated list
+                                        // of values (,\s*Position,)|(^\s*Position\s*,)|(,\s*Position\s*$)|(^\s*Position\s*$)
+                                        `REGEXP_MATCHES("${column}", '(,\\s*${value}\\s*,)|(^\\s*${value}\\s*,)|(,\\s*${value}\\s*$)|(^\\s*${value}\\s*$)') = true`
                                 )
                             )
                             .join(") OR (")


### PR DESCRIPTION
Previously the regular expression that is used to look for a value among a comma separated list of values was not matching on values that had whitespace in varying amounts. I updated the regular expression to look explicitly for one of:
* A match at the beginning of a comma separated list
* A match in the middle of a comma separated list
* A match at the end of a comma separated list
* A match that is the entire value (AKA no list, just one value)