### PR TITLE
Fix tutorial behavior and styling

### DIFF
--- a/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
+++ b/packages/core/components/TutorialTooltip/TutorialTooltip.module.css
@@ -33,7 +33,7 @@
 }
 
 .tutorial-container > div {
-    background-color: var(--primary-background-color);
+    background-color: var(--accent-dark);
     border-radius: var(--small-border-radius);
     color: var(--primary-text-color);
 }

--- a/packages/core/components/TutorialTooltip/index.tsx
+++ b/packages/core/components/TutorialTooltip/index.tsx
@@ -18,10 +18,17 @@ export default function TutorialTooltip() {
     if (!tutorial) {
         return null;
     }
+    const resetToFirstStep = () => {
+        setTutorialStepIndex(0);
+        return tutorial.getStep(0);
+    };
 
     const nextStepIndex = tutorialStepIndex + 1;
     const previousStepIndex = tutorialStepIndex - 1;
-    const currentTutorialStep = tutorial.getStep(tutorialStepIndex);
+    // If switching from another tooltip, may be out of index range and should reset
+    const currentTutorialStep = tutorial.hasStep(tutorialStepIndex)
+        ? tutorial.getStep(tutorialStepIndex)
+        : resetToFirstStep();
 
     const onDismiss = () => {
         setTutorialStepIndex(0);
@@ -40,7 +47,11 @@ export default function TutorialTooltip() {
         <TeachingBubble
             isWide
             target={`#${currentTutorialStep.targetId}`}
-            calloutProps={{ className: styles.tutorialContainer }}
+            calloutProps={{
+                className: styles.tutorialContainer,
+                minPagePadding: 50, // Prevent tutorial cutoff for small screens
+            }}
+            focusTrapZoneProps={{ disabled: true }}
         >
             <div className={styles.header}>
                 <h4>Tutorial: {tutorial.title}</h4>


### PR DESCRIPTION
## Context
Fixes a few tutorial tooltip bugs:
- Background actions were non-focusable while tutorial was open, couldn't switch to other tutorial or open other menus
- Some tutorials got cut off for some small screen sizes
- Color blended into the background

### NOT completed:
- Clicking outside to close. This is a limitation of the library we're using. If we do end up wanting this, may need to switch to a slightly different implementation

closes #189, #172 

## Testing
Tested manually for web & desktop

## Screenshot
Color change to slightly lighter grey to not match background -- Should we go even lighter?
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7dac7fe0-5942-4c84-8a20-6b360efdfe51">